### PR TITLE
Add support for git/docker tag mapping

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,10 +33,10 @@ jobs:
           command: docker login -u "$DOCKER_USER" -p "$DOCKER_PASS"
       - run:
           name: Build container
-          command: docker build -t candihub/pixel:"$CIRCLE_BRANCH" .
+          command: docker build -t "candihub/pixel:$CIRCLE_BRANCH" .
       - run:
           name: Publish container
-          command: docker push candihub/pixel:"$CIRCLE_BRANCH"
+          command: docker push "candihub/pixel:$CIRCLE_BRANCH"
 
   docker-tag:
     machine: true
@@ -46,10 +46,10 @@ jobs:
           command: docker login -u "$DOCKER_USER" -p "$DOCKER_PASS"
       - run:
           name: Tag container
-          command: docker tag candihub/pixel:"$CIRCLE_BRANCH" candihub/pixel:$(bin/ci --get-docker-tag)
+          command: docker tag "candihub/pixel:$CIRCLE_BRANCH" "candihub/pixel:$(bin/ci --get-docker-tag)"
       - run:
           name: Publish tagged container
-          command: docker push candihub/pixel:$(bin/ci --get-docker-tag)
+          command: docker push "candihub/pixel:$(bin/ci --get-docker-tag)"
 
   backend-build-dev:
     working_directory: /app/pixel

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,19 @@ jobs:
           name: Publish container
           command: docker push candihub/pixel:"$CIRCLE_BRANCH"
 
+  docker-tag:
+    machine: true
+    steps:
+      - run:
+          name: Login to DockerHub
+          command: docker login -u "$DOCKER_USER" -p "$DOCKER_PASS"
+      - run:
+          name: Tag container
+          command: docker tag candihub/pixel:"$CIRCLE_BRANCH" candihub/pixel:$(bin/ci --get-docker-tag)
+      - run:
+          name: Publish tagged container
+          command: docker push candihub/pixel:$(bin/ci --get-docker-tag)
+
   backend-build-dev:
     working_directory: /app/pixel
     docker:
@@ -130,3 +143,12 @@ workflows:
       - backend-test:
           requires:
             - backend-build-dev
+      - docker-tag:
+          requires:
+            - backend-test
+            - backend-lint
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              only: master

--- a/bin/ci
+++ b/bin/ci
@@ -9,6 +9,7 @@ function usage() {
     echo "  -h|--help           : Display this help message"
     echo "  --set-git-repo      : Setup git repository from raw sources"
     echo "  --install-dockerize : Install dockerize tool"
+    echo "  --get-docker-tag    : Output docker tag given ci branch name"
     echo
 
     exit 1
@@ -36,6 +37,22 @@ function install_dockerize() {
     rm "$archive"
 }
 
+function get_docker_tag() {
+    local tag="$CIRCLE_BRANCH"
+
+    if [ "$tag" == "master" ]
+    then
+        tag="latest"
+    fi
+
+    if [ "$CIRCLE_TAG" != "" ]
+    then
+        tag="$CIRCLE_TAG"
+    fi
+
+    echo "$tag"
+}
+
 function main() {
   declare program="$0"
 
@@ -50,6 +67,9 @@ function main() {
               ;;
           --install-dockerize)
               install_dockerize
+              ;;
+          --get-docker-tag)
+              get_docker_tag
               ;;
           -h|--help|help)
               usage "$program"


### PR DESCRIPTION
This PR addresses issue #44.

In this PR we `docker tag` current job build with `latest` for the `master` branch and `$CIRCLE_TAG` for a git tag build and then push this image with the new tag.


