### PR TITLE
Wait a bit before applying migrations on make bootstrap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,12 @@ SASS     = $(YARN_RUN) node-sass
 default: help
 
 bootstrap: ## install development dependencies
-	@if [ -z "$$CI" ] || [ -n "$$CI_BUILD_BACKEND" ]; then $(COMPOSE) build web; ${MAKE} migrate-db; fi
+	@if [ -z "$$CI" ] || [ -n "$$CI_BUILD_BACKEND" ]; then \
+		$(COMPOSE) build web; \
+		echo 'Waiting until database is up'; \
+		sleep 20; \
+		${MAKE} migrate-db; \
+	fi
 	@if [ -z "$$CI" ] || [ -n "$$CI_BUILD_FRONTEND" ]; then $(YARN_RUN) install -D; ${MAKE} build-css; fi
 .PHONY: bootstrap
 


### PR DESCRIPTION
The current value is set to `20` seconds, but it could be increased if needed.
Because it likely only happens on bootstrap, I don't think we need to add
dockerize, wait-for-it, or any other complicated script. It is fine to wait 20
seconds to get the app ready to use.