### PR TITLE
Display error message when importation fails

### DIFF
--- a/apps/submission/templates/submission/submission/import_archive_detail.html
+++ b/apps/submission/templates/submission/submission/import_archive_detail.html
@@ -1,12 +1,13 @@
 {% extends "submission/submission/task_detail.html" %}
 
 {% load i18n %}
+{% load submission %}
 
 {% block body_class %}{{ block.super }} import{% endblock %}
 
 {% block step_content %}
 
-{% if activation.task.status == 'DONE' %}
+{% if activation.task|is_completed %}
   {{ block.super }}
 {% else %}
   <div class="disclaimer">

--- a/apps/submission/templatetags/submission.py
+++ b/apps/submission/templatetags/submission.py
@@ -42,6 +42,19 @@ def core_tasks(tasks):
     return filtered
 
 
+@register.filter
+def is_completed(task):
+    """Check if a task has been completed.
+
+    Note that a failed task is considered as completed.
+
+    Returns: True if status is ended or error
+    """
+    if task.status in (STATUS.DONE, STATUS.ERROR, STATUS.CANCELED):
+        return True
+    return False
+
+
 @register.simple_tag
 def submission_ratio(process):
     """Calculates achived tasks ratio for a given submission process

--- a/apps/submission/tests/test_templatetags.py
+++ b/apps/submission/tests/test_templatetags.py
@@ -1,7 +1,9 @@
+from unittest.mock import Mock
 from pathlib import Path
 
 from django.test import TestCase, TransactionTestCase
 from django.urls import reverse
+from viewflow.activation import STATUS
 
 from ..models import SubmissionProcess
 from ..templatetags import submission
@@ -94,6 +96,18 @@ class CoreTasksFilterTestCase(TagsTestMixin,
             tasks,
             expected
         )
+
+
+class IsCompletedTestCase(TestCase):
+
+    def test_is_completed(self):
+
+        self.assertTrue(submission.is_completed(Mock(status=STATUS.DONE)))
+        self.assertTrue(submission.is_completed(Mock(status=STATUS.ERROR)))
+        self.assertTrue(submission.is_completed(Mock(status=STATUS.CANCELED)))
+        self.assertFalse(submission.is_completed(Mock(status=STATUS.ASSIGNED)))
+        self.assertFalse(submission.is_completed(Mock(status=STATUS.NEW)))
+        self.assertFalse(submission.is_completed(Mock(status='whatever')))
 
 
 class SubmissionRatioTestCase(StartTestMixin,


### PR DESCRIPTION
## Purpose

Fix the following bug: 

* an error occurs while importing an archive
* the importation wait page does not display the error message because it is waiting for the wrong status

See snapshot:

![screenshot-2018-1-18 submission details 23](https://user-images.githubusercontent.com/956157/35099886-f1608084-fc59-11e7-8a99-5eb8017c94e5.png)

## Proposal

Implement a `is_completed` template tag filter to check task status.
