### PR TITLE
Prevent click on current submission step

### DIFF
--- a/assets/scss/_submission.scss
+++ b/assets/scss/_submission.scss
@@ -24,7 +24,9 @@
         & > a[aria-selected="true"] {
           background-color: inherit;
           color: inherit;
+          cursor: not-allowed;
           font-weight: bolder;
+          pointer-events: none;
         }
       }
     }


### PR DESCRIPTION
This prevents the user to click on the current submission step, which could
cause weird error messages or invalid-ish states (from a UI/UX perspective, the
backend code is OK).