### PR TITLE
Add pixelset search

### DIFF
--- a/apps/core/models.py
+++ b/apps/core/models.py
@@ -241,25 +241,22 @@ class PixelSet(UUIDModelMixin, models.Model):
         verbose_name_plural = _("Pixel sets")
 
     def get_omics_areas(self):
-        return OmicsArea.objects.filter(
-            experiment__in=self.analysis.experiments.all()
-        ).distinct().values_list(
-            'name', flat=True
-        )
+        return set(self.analysis.experiments.values_list(
+            'omics_area__name',
+            flat=True
+        ))
 
     def get_omics_unit_types(self):
-        return OmicsUnitType.objects.filter(
-            omics_unit__pixel__in=self.pixels.all()
-        ).distinct().values_list(
-            'name', flat=True
-        )
+        return set(self.pixels.values_list(
+            'omics_unit__type__name',
+            flat=True
+        ))
 
     def get_species(self):
-        return Species.objects.filter(
-            strain__omics_unit__pixel__in=self.pixels.all()
-        ).distinct().values_list(
-            'name', flat=True
-        )
+        return set(self.pixels.values_list(
+            'omics_unit__strain__species__name',
+            flat=True
+        ))
 
 
 class Pixel(UUIDModelMixin, models.Model):

--- a/apps/core/tests/test_models.py
+++ b/apps/core/tests/test_models.py
@@ -377,11 +377,13 @@ class PixelSetTestCase(CoreFixturesTestCase):
 
     def test_get_omics_unit_types(self):
 
-        expected = models.OmicsUnitType.objects.values_list('name', flat=True)
-        self.assertEqual(
-            list(self.pixel_set.get_omics_unit_types()),
-            list(expected),
+        types = list(self.pixel_set.get_omics_unit_types())
+        types.sort()
+        expected = list(
+            models.OmicsUnitType.objects.values_list('name', flat=True)
         )
+        expected.sort()
+        self.assertEqual(types, expected)
 
     def test_get_species(self):
 

--- a/apps/explorer/forms.py
+++ b/apps/explorer/forms.py
@@ -35,3 +35,16 @@ class PixelSetFiltersForm(forms.Form):
         widget=forms.CheckboxSelectMultiple,
         required=False,
     )
+
+    search = forms.CharField(
+        label=_("Search"),
+        widget=forms.TextInput(
+            attrs={
+                'placeholder': _("CAGL0A02321g"),
+            }
+        ),
+        help_text=_(
+            "Type a gene name or a key word, e.g. CAGL0A02321g or LIMMA"
+        ),
+        required=False,
+    )

--- a/apps/explorer/tests/test_views.py
+++ b/apps/explorer/tests/test_views.py
@@ -1,6 +1,7 @@
 from django.core.urlresolvers import reverse
 
 from apps.core import factories, models
+from apps.core.templatetags.files import filename
 from apps.core.tests import CoreFixturesTestCase
 from apps.core.management.commands.make_development_fixtures import (
     make_development_fixtures
@@ -354,6 +355,132 @@ class PixelSetListViewTestCase(CoreFixturesTestCase):
                 '<td colspan="8" class="empty">'
                 'No pixel set matches your query'
                 '</td>'
+            ),
+            count=1,
+            html=True,
+        )
+
+    def test_search_filter_with_omics_unit_reference(self):
+
+        # Create 8 pixelset
+        make_development_fixtures(
+            n_pixel_sets=8,
+            n_pixels_per_set=1
+        )
+
+        pixel_set = models.PixelSet.objects.all()[4]
+        reference = pixel_set.pixels.get().omics_unit.reference.identifier
+
+        # no filter
+        response = self.client.get(self.url)
+        self.assertContains(
+            response,
+            '<tr class="pixelset">',
+            count=8
+        )
+
+        # filter with Omics Unit reference identifier search
+        data = {
+            'search': reference
+        }
+        response = self.client.get(self.url, data)
+        self.assertContains(
+            response,
+            '<tr class="pixelset">',
+            count=1
+        )
+        self.assertContains(
+            response,
+            (
+                '<td class="filename">'
+                '<!-- Pixel set file name -->'
+                '{}'
+                '</td>'
+            ).format(
+                filename(pixel_set.pixels_file.name)
+            ),
+            count=1,
+            html=True,
+        )
+
+    def test_search_filter_with_keywords(self):
+
+        # Create 8 pixelset
+        make_development_fixtures(
+            n_pixel_sets=8,
+            n_pixels_per_set=1
+        )
+
+        # Add custom descriptions written in Klingon so that we are pretty
+        # sure nothing will match our query 🤓
+        #
+        # Lorem ipsum source:
+        # http://shooshee.tumblr.com/post/212964026/klingon-lorem-ipsum
+        first_analysis = factories.AnalysisFactory(
+            description=(
+                'Qapla. Dah tlhingan hol mu ghom a dalegh. Qawhaqvam '
+                'chenmohlu di wiqipe diya ohvad ponglu. Ach jinmolvamvad '
+                'Saghbe law tlhingan hol, dis, oh mevmohlu.'
+            )
+        )
+
+        experiment = factories.ExperimentFactory(
+            description=(
+                'Qapla. Dah tlhingan hol mu ghom a dalegh. Qawhaqvam '
+                'chenmohlu di wiqipe diya ohvad ponglu. Ach jinmolvamvad '
+                'Saghbe law tlhingan hol, dis, oh mevmohlu.'
+            )
+        )
+        second_analysis = factories.AnalysisFactory(experiments=[experiment, ])
+
+        first_pixel_set = models.PixelSet.objects.all()[4]
+        first_pixel_set.analysis = first_analysis
+        first_pixel_set.save()
+
+        second_pixel_set = models.PixelSet.objects.all()[6]
+        second_pixel_set.analysis = second_analysis
+        second_pixel_set.save()
+
+        # no filter
+        response = self.client.get(self.url)
+        self.assertContains(
+            response,
+            '<tr class="pixelset">',
+            count=8
+        )
+
+        # filter with keyword search
+        data = {
+            'search': 'jinmolvamvad'
+        }
+        response = self.client.get(self.url, data)
+        self.assertContains(
+            response,
+            '<tr class="pixelset">',
+            count=2
+        )
+        self.assertContains(
+            response,
+            (
+                '<td class="filename">'
+                '<!-- Pixel set file name -->'
+                '{}'
+                '</td>'
+            ).format(
+                filename(first_pixel_set.pixels_file.name)
+            ),
+            count=1,
+            html=True,
+        )
+        self.assertContains(
+            response,
+            (
+                '<td class="filename">'
+                '<!-- Pixel set file name -->'
+                '{}'
+                '</td>'
+            ).format(
+                filename(second_pixel_set.pixels_file.name)
             ),
             count=1,
             html=True,

--- a/apps/explorer/tests/test_views.py
+++ b/apps/explorer/tests/test_views.py
@@ -464,10 +464,8 @@ class PixelSetListViewTestCase(CoreFixturesTestCase):
             (
                 '<td class="filename">'
                 '<!-- Pixel set file name -->'
-                '{}'
+                f'{filename(first_pixel_set.pixels_file.name)}'
                 '</td>'
-            ).format(
-                filename(first_pixel_set.pixels_file.name)
             ),
             count=1,
             html=True,
@@ -477,10 +475,8 @@ class PixelSetListViewTestCase(CoreFixturesTestCase):
             (
                 '<td class="filename">'
                 '<!-- Pixel set file name -->'
-                '{}'
+                f'{filename(second_pixel_set.pixels_file.name)}'
                 '</td>'
-            ).format(
-                filename(second_pixel_set.pixels_file.name)
             ),
             count=1,
             html=True,

--- a/apps/explorer/views.py
+++ b/apps/explorer/views.py
@@ -73,15 +73,22 @@ class PixelSetListView(LoginRequiredMixin, FormMixin, ListView):
                                 delimiter=' '
                             )
                         ) +
-                        SearchVector('pixel__omics_unit__reference__identifier')  # noqa
+                        SearchVector(
+                            'pixel__omics_unit__reference__identifier'
+                        )
                     )
                 ).filter(search=search)
 
-        return qs.distinct().prefetch_related(
+        # optimize db queries
+        qs = qs.select_related(
+            'analysis',
+            'analysis__pixeler',
+        ).prefetch_related(
             'analysis__experiments__omics_area',
             'analysis__experiments__tags',
-            'analysis__pixeler',
             'analysis__tags',
             'pixels__omics_unit__type',
             'pixels__omics_unit__strain__species',
         )
+
+        return qs.distinct()

--- a/assets/scss/_commons.scss
+++ b/assets/scss/_commons.scss
@@ -29,6 +29,10 @@ form {
             color: $alert-color;
           }
         }
+
+        input {
+          margin-bottom: 0.2rem;
+        }
       }
 
       p.help-text {

--- a/assets/scss/_layout.scss
+++ b/assets/scss/_layout.scss
@@ -68,6 +68,7 @@
 
   .page-content-wrapper {
     @include xy-grid-container;
+    flex: 1;
 
     .page-content {
       @include xy-grid($wrap: false);


### PR DESCRIPTION
## Purpose

Add a new search field to the `PixelSetListView`.

## Proposal

The current search implementation works as a filter that will look for matching:

* Omics Units reference identifier in pixels
* keywords in Analysis's description
* keywords in Experiment's description

## Sneak peek

![screenshot-2018-1-25 pixel sets](https://user-images.githubusercontent.com/956157/35391472-1a71ad1a-01df-11e8-896c-5f8b11c442c3.png)
