### PR TITLE
Export pixel sets

### DIFF
--- a/apps/explorer/forms.py
+++ b/apps/explorer/forms.py
@@ -48,3 +48,14 @@ class PixelSetFiltersForm(forms.Form):
         ),
         required=False,
     )
+
+
+class PixelSetExportForm(forms.Form):
+
+    pixel_sets = forms.ModelMultipleChoiceField(
+        queryset=models.PixelSet.objects.all(),
+        widget=forms.CheckboxSelectMultiple,
+        error_messages={
+            'required': _('You must select at least one Pixel Set.'),
+        },
+    )

--- a/apps/explorer/templates/explorer/pixelset_list.html
+++ b/apps/explorer/templates/explorer/pixelset_list.html
@@ -37,92 +37,98 @@
     {{ export_form.non_field_errors }}
   </div>
 
-  <form action="{% url 'explorer:pixelset_export' %}" method="post">
+  <form action="{% url 'explorer:pixelset_export' %}" method="post" id="export-form">
     {% csrf_token %}
     <input type="hidden" name="redirect_to" value="{{ request.build_absolute_uri }}">
 
-    <table class="pixelsets">
-      <thead>
-        <tr>
-          <th colspan="2">{% trans "Pixel set" %}</th>
-          <th>{% trans "Species" %}</th>
-          <th>{% trans "Omics Unit type" %}</th>
-          <th>{% trans "Omics area" %}</th>
-          <th>{% trans "Pixeler" %}</th>
-          <th>{% trans "Analysis" %}</th>
-          <th>{% trans "Experiment" %}</th>
-          <th>{% trans "Tags" %}</th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for pixelset in pixelset_list %}
-        <tr class="pixelset">
-          <td>
-            <input name="pixel_sets" value="{{ pixelset.id }}" type="checkbox">
-          </td>
-          <td class="filename">
-            <!-- Pixel set file name -->
-            {{ pixelset.pixels_file.name|filename }}
-          </td>
-          <td class="species">
-            <!-- Species-->
-            {% for species in pixelset.get_species %}
-              <span class="species">{{ species }}</span>
-            {% endfor %}
-          </td>
-          <td class="omics-unit-types">
-            <!-- Omics Unit Type -->
-            {% for type in pixelset.get_omics_unit_types %}
-              <span class="omics-unit-type">{{ type }}</span>
-            {% endfor %}
-          </td>
-          <td class="omics-areas">
-            <!-- Omics Area -->
-            {% for area in pixelset.get_omics_areas %}
-              <span class="omics-area">{{ area }}</span>
-            {% endfor %}
-          </td>
-          <td class="pixeler">
-            <!-- Pixeler -->
-            {{ pixelset.analysis.pixeler.get_full_name }}
-          </td>
-          <td class="analysis">
-            <!-- Analysis -->
-            {{ pixelset.analysis.description }}
-          </td>
-          <td class="experiments">
-            <!-- Experiment -->
-            {% for experiment in pixelset.analysis.experiments.all %}
+    <div class="pixelsets-wrapper">
+      <table class="pixelsets">
+        <thead>
+          <tr>
+            <th>#</th>
+            <th>{% trans "Pixel set" %}</th>
+            <th>{% trans "Species" %}</th>
+            <th>{% trans "Omics Unit type" %}</th>
+            <th>{% trans "Omics area" %}</th>
+            <th>{% trans "Pixeler" %}</th>
+            <th>{% trans "Analysis" %}</th>
+            <th>{% trans "Experiment" %}</th>
+            <th>{% trans "Tags" %}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for pixelset in pixelset_list %}
+          <tr class="pixelset">
+            <td>
+              <input name="pixel_sets" value="{{ pixelset.id }}" type="checkbox">
+            </td>
+            <td class="filename">
+              <!-- Pixel set file name -->
+              {{ pixelset.pixels_file.name|filename }}
+            </td>
+            <td class="species">
+              <!-- Species-->
+              {% for species in pixelset.get_species %}
+                <span class="species">{{ species }}</span>
+              {% endfor %}
+            </td>
+            <td class="omics-unit-types">
+              <!-- Omics Unit Type -->
+              {% for type in pixelset.get_omics_unit_types %}
+                <span class="omics-unit-type">{{ type }}</span>
+              {% endfor %}
+            </td>
+            <td class="omics-areas">
+              <!-- Omics Area -->
+              {% for area in pixelset.get_omics_areas %}
+                <span class="omics-area">{{ area }}</span>
+              {% endfor %}
+            </td>
+            <td class="pixeler">
+              <!-- Pixeler -->
+              {{ pixelset.analysis.pixeler.get_full_name }}
+            </td>
+            <td class="analysis">
+              <!-- Analysis -->
+              {{ pixelset.analysis.description }}
+            </td>
+            <td class="experiments">
+              <!-- Experiment -->
+              {% for experiment in pixelset.analysis.experiments.all %}
               <span class="experiment">
                 {{ experiment.description }}
               </span>
-            {% endfor %}
-          </td>
-          <td class="tags">
-            <!-- Tags -->
-            {% for tag in pixelset.analysis.tags.all %}
-              <span class="tag analysis">{{ tag }}</span>
-            {% endfor %}
-            {% for experiment in pixelset.analysis.experiments.all %}
-              {% for tag in experiment.tags.all %}
-                <span class="tag experiment">{{ tag }}</span>
               {% endfor %}
-            {% endfor %}
-          </td>
-        </tr>
-        {% empty %}
-        <tr>
-          <td colspan="8" class="empty">
-            {% trans "No pixel set matches your query" %}
-          </td>
-        </tr>
-        {% endfor %}
-      </tbody>
-    </table>
+            </td>
+            <td class="tags">
+              <!-- Tags -->
+              {% for tag in pixelset.analysis.tags.all %}
+                <span class="tag analysis">{{ tag }}</span>
+              {% endfor %}
+              {% for experiment in pixelset.analysis.experiments.all %}
+                {% for tag in experiment.tags.all %}
+                  <span class="tag experiment">{{ tag }}</span>
+                {% endfor %}
+              {% endfor %}
+            </td>
+          </tr>
+          {% empty %}
+          <tr>
+            <td colspan="8" class="empty">
+              {% trans "No pixel set matches your query" %}
+            </td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
 
-    <button type="submit" class="button">
-      {% trans "Export" %}
-    </button>
+    <div class="actions">
+      <button type="submit" class="button">
+        <i class="fa fa-download" aria-hidden="true"></i>
+        {% trans "Download an archive (.zip) with the selected Pixel sets" %}
+      </button>
+    </div>
   </form>
 
   {% include "foundation/pagination.html" %}

--- a/apps/explorer/templates/explorer/pixelset_list.html
+++ b/apps/explorer/templates/explorer/pixelset_list.html
@@ -123,12 +123,14 @@
       </table>
     </div>
 
+    {% if pixelset_list %}
     <div class="actions">
       <button type="submit" class="button">
         <i class="fa fa-download" aria-hidden="true"></i>
         {% trans "Download an archive (.zip) with the selected Pixel sets" %}
       </button>
     </div>
+    {% endif %}
   </form>
 
   {% include "foundation/pagination.html" %}

--- a/apps/explorer/templates/explorer/pixelset_list.html
+++ b/apps/explorer/templates/explorer/pixelset_list.html
@@ -130,8 +130,25 @@
         {% trans "Download an archive (.zip) with the selected Pixel sets" %}
       </button>
     </div>
+
+    <hr>
     {% endif %}
   </form>
 
   {% include "foundation/pagination.html" %}
 {% endblock content %}
+
+{% block javascript %}
+<script>
+  (function (document) {
+    $rows = document.querySelectorAll('.pixelset');
+
+    $rows.forEach(function ($row) {
+      $row.addEventListener('click', function () {
+        var $checkbox = this.querySelector('input[type="checkbox"]');
+        $checkbox.checked = !$checkbox.checked;
+      });
+    });
+  })(document);
+</script>
+{% endblock %}

--- a/apps/explorer/templates/explorer/pixelset_list.html
+++ b/apps/explorer/templates/explorer/pixelset_list.html
@@ -33,81 +33,97 @@
 {% endblock sidebar-left %}
 
 {% block content %}
-  <table class="pixelsets">
-    <thead>
-      <tr>
-        <th>{% trans "Pixel set" %}</th>
-        <th>{% trans "Species" %}</th>
-        <th>{% trans "Omics Unit type" %}</th>
-        <th>{% trans "Omics area" %}</th>
-        <th>{% trans "Pixeler" %}</th>
-        <th>{% trans "Analysis" %}</th>
-        <th>{% trans "Experiment" %}</th>
-        <th>{% trans "Tags" %}</th>
-      </tr>
-    </thead>
-    <tbody>
-      {% for pixelset in pixelset_list %}
-      <tr class="pixelset">
-        <td class="filename">
-          <!-- Pixel set file name -->
-          {{ pixelset.pixels_file.name|filename }}
-        </td>
-        <td class="species">
-          <!-- Species-->
-          {% for species in pixelset.get_species %}
-            <span class="species">{{ species }}</span>
-          {% endfor %}
-        </td>
-        <td class="omics-unit-types">
-          <!-- Omics Unit Type -->
-          {% for type in pixelset.get_omics_unit_types %}
-            <span class="omics-unit-type">{{ type }}</span>
-          {% endfor %}
-        </td>
-        <td class="omics-areas">
-          <!-- Omics Area -->
-          {% for area in pixelset.get_omics_areas %}
-            <span class="omics-area">{{ area }}</span>
-          {% endfor %}
-        </td>
-        <td class="pixeler">
-          <!-- Pixeler -->
-          {{ pixelset.analysis.pixeler.get_full_name }}
-        </td>
-        <td class="analysis">
-          <!-- Analysis -->
-          {{ pixelset.analysis.description }}
-        </td>
-        <td class="experiments">
-          <!-- Experiment -->
-          {% for experiment in pixelset.analysis.experiments.all %}
-            <span class="experiment">
-              {{ experiment.description }}
-            </span>
-          {% endfor %}
-        </td>
-        <td class="tags">
-          <!-- Tags -->
-          {% for tag in pixelset.analysis.tags.all %}
-            <span class="tag analysis">{{ tag }}</span>
-          {% endfor %}
-          {% for experiment in pixelset.analysis.experiments.all %}
-            {% for tag in experiment.tags.all %}
-              <span class="tag experiment">{{ tag }}</span>
+  <div class="form-error">
+    {{ export_form.non_field_errors }}
+  </div>
+
+  <form action="{% url 'explorer:pixelset_export' %}" method="post">
+    {% csrf_token %}
+    <input type="hidden" name="redirect_to" value="{{ request.build_absolute_uri }}">
+
+    <table class="pixelsets">
+      <thead>
+        <tr>
+          <th colspan="2">{% trans "Pixel set" %}</th>
+          <th>{% trans "Species" %}</th>
+          <th>{% trans "Omics Unit type" %}</th>
+          <th>{% trans "Omics area" %}</th>
+          <th>{% trans "Pixeler" %}</th>
+          <th>{% trans "Analysis" %}</th>
+          <th>{% trans "Experiment" %}</th>
+          <th>{% trans "Tags" %}</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for pixelset in pixelset_list %}
+        <tr class="pixelset">
+          <td>
+            <input name="pixel_sets" value="{{ pixelset.id }}" type="checkbox">
+          </td>
+          <td class="filename">
+            <!-- Pixel set file name -->
+            {{ pixelset.pixels_file.name|filename }}
+          </td>
+          <td class="species">
+            <!-- Species-->
+            {% for species in pixelset.get_species %}
+              <span class="species">{{ species }}</span>
             {% endfor %}
-          {% endfor %}
-        </td>
-      </tr>
-      {% empty %}
-      <tr>
-        <td colspan="8" class="empty">
-          {% trans "No pixel set matches your query" %}
-        </td>
-      </tr>
-      {% endfor %}
-    </tbody>
-  </table>
+          </td>
+          <td class="omics-unit-types">
+            <!-- Omics Unit Type -->
+            {% for type in pixelset.get_omics_unit_types %}
+              <span class="omics-unit-type">{{ type }}</span>
+            {% endfor %}
+          </td>
+          <td class="omics-areas">
+            <!-- Omics Area -->
+            {% for area in pixelset.get_omics_areas %}
+              <span class="omics-area">{{ area }}</span>
+            {% endfor %}
+          </td>
+          <td class="pixeler">
+            <!-- Pixeler -->
+            {{ pixelset.analysis.pixeler.get_full_name }}
+          </td>
+          <td class="analysis">
+            <!-- Analysis -->
+            {{ pixelset.analysis.description }}
+          </td>
+          <td class="experiments">
+            <!-- Experiment -->
+            {% for experiment in pixelset.analysis.experiments.all %}
+              <span class="experiment">
+                {{ experiment.description }}
+              </span>
+            {% endfor %}
+          </td>
+          <td class="tags">
+            <!-- Tags -->
+            {% for tag in pixelset.analysis.tags.all %}
+              <span class="tag analysis">{{ tag }}</span>
+            {% endfor %}
+            {% for experiment in pixelset.analysis.experiments.all %}
+              {% for tag in experiment.tags.all %}
+                <span class="tag experiment">{{ tag }}</span>
+              {% endfor %}
+            {% endfor %}
+          </td>
+        </tr>
+        {% empty %}
+        <tr>
+          <td colspan="8" class="empty">
+            {% trans "No pixel set matches your query" %}
+          </td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+
+    <button type="submit" class="button">
+      {% trans "Export" %}
+    </button>
+  </form>
 
   {% include "foundation/pagination.html" %}
 {% endblock content %}

--- a/apps/explorer/tests/test_views.py
+++ b/apps/explorer/tests/test_views.py
@@ -565,9 +565,7 @@ class PixelSetExportViewTestCase(CoreFixturesTestCase):
             self.assertEqual(
                 response['Content-Disposition'],
                 'attachment; filename={}'.format(
-                    PixelSetExportView.ATTACHEMENT_FILENAME.format(
-                        date_time=fake_dt.strftime('%Y%m%d_%Hh%Mm%Ss')
-                    )
+                    PixelSetExportView.get_export_archive_filename()
                 )
             )
 

--- a/apps/explorer/tests/test_views.py
+++ b/apps/explorer/tests/test_views.py
@@ -41,6 +41,19 @@ class PixelSetListViewTestCase(CoreFixturesTestCase):
         )
         self.assertContains(response, expected, html=True)
 
+    def test_does_not_render_export_button_when_no_pixelsets(self):
+
+        response = self.client.get(self.url)
+
+        expected = (
+            '<button type="submit" class="button">',
+            '<i class="fa fa-download" aria-hidden="true"></i>'
+            'Download an archive (.zip) with the selected Pixel sets',
+            '</button>'
+        )
+
+        self.assertNotContains(response, expected, html=True)
+
     def test_renders_pixelset_list(self):
 
         make_development_fixtures(n_pixel_sets=12)
@@ -50,6 +63,10 @@ class PixelSetListViewTestCase(CoreFixturesTestCase):
             response,
             '<tr class="pixelset">',
             count=10
+        )
+        self.assertContains(
+            response,
+            '<button type="submit" class="button button-export">',
         )
 
     def test_species_filter(self):

--- a/apps/explorer/tests/test_views.py
+++ b/apps/explorer/tests/test_views.py
@@ -8,6 +8,7 @@ from apps.core.tests import CoreFixturesTestCase
 from apps.core.management.commands.make_development_fixtures import (
     make_development_fixtures
 )
+from apps.explorer.views import PixelSetExportView
 
 
 class PixelSetListViewTestCase(CoreFixturesTestCase):
@@ -555,7 +556,9 @@ class PixelSetExportViewTestCase(CoreFixturesTestCase):
         self.assertEqual(response['Content-Type'], 'application/zip')
         self.assertEqual(
             response['Content-Disposition'],
-            'attachment; filename=pixelsets.zip'
+            'attachment; filename={}'.format(
+                PixelSetExportView.ATTACHEMENT_FILENAME
+            )
         )
 
         try:

--- a/apps/explorer/tests/utils/test_export.py
+++ b/apps/explorer/tests/utils/test_export.py
@@ -1,6 +1,7 @@
 import pandas
 import pytest
 import yaml
+import zipfile
 
 from apps.core import factories
 from apps.core.models import PixelSet
@@ -14,6 +15,11 @@ from ...utils import (
 
 class ExportPixelSetsTestCase(CoreFixturesTestCase):
 
+    def _export_pixelsets(self, pixel_sets):
+
+        stream = export_pixelsets(pixel_sets)
+        return zipfile.ZipFile(stream, mode='r')
+
     def _assert_archive_is_valid(self, zip_archive):
 
         assert len(zip_archive.namelist()) == 2
@@ -22,7 +28,7 @@ class ExportPixelSetsTestCase(CoreFixturesTestCase):
 
     def test_export_without_pixelsets(self):
 
-        zip_archive = export_pixelsets(PixelSet.objects.none())
+        zip_archive = self._export_pixelsets(PixelSet.objects.none())
         self._assert_archive_is_valid(zip_archive)
 
         with zip_archive.open(PIXELSET_EXPORT_META_FILENAME) as meta_file:
@@ -40,7 +46,7 @@ class ExportPixelSetsTestCase(CoreFixturesTestCase):
 
         pixel_sets = factories.PixelSetFactory.create_batch(1)
 
-        zip_archive = export_pixelsets(pixel_sets)
+        zip_archive = self._export_pixelsets(pixel_sets)
         self._assert_archive_is_valid(zip_archive)
 
         with zip_archive.open(PIXELSET_EXPORT_META_FILENAME) as meta_file:
@@ -60,7 +66,7 @@ class ExportPixelSetsTestCase(CoreFixturesTestCase):
         for pixel_set in pixel_sets:
             factories.PixelFactory.create_batch(3, pixel_set=pixel_set)
 
-        zip_archive = export_pixelsets(pixel_sets)
+        zip_archive = self._export_pixelsets(pixel_sets)
         self._assert_archive_is_valid(zip_archive)
 
         with zip_archive.open(PIXELSET_EXPORT_META_FILENAME) as meta_file:
@@ -87,7 +93,7 @@ class ExportPixelSetsTestCase(CoreFixturesTestCase):
         for pixel_set in pixel_sets:
             factories.PixelFactory.create_batch(3, pixel_set=pixel_set)
 
-        zip_archive = export_pixelsets([*list(pixel_sets), *list(pixel_sets)])
+        zip_archive = self._export_pixelsets([*list(pixel_sets), *list(pixel_sets)])
         self._assert_archive_is_valid(zip_archive)
 
         with zip_archive.open(PIXELSET_EXPORT_META_FILENAME) as meta_file:
@@ -109,7 +115,7 @@ class ExportPixelSetsTestCase(CoreFixturesTestCase):
         # we add pixels on the same set
         pixel_sets[0].pixels.add(*pixels)
 
-        zip_archive = export_pixelsets(list(pixel_sets))
+        zip_archive = self._export_pixelsets(list(pixel_sets))
         self._assert_archive_is_valid(zip_archive)
 
         with zip_archive.open(PIXELSET_EXPORT_META_FILENAME) as meta_file:

--- a/apps/explorer/tests/utils/test_export.py
+++ b/apps/explorer/tests/utils/test_export.py
@@ -93,7 +93,9 @@ class ExportPixelSetsTestCase(CoreFixturesTestCase):
         for pixel_set in pixel_sets:
             factories.PixelFactory.create_batch(3, pixel_set=pixel_set)
 
-        zip_archive = self._export_pixelsets([*list(pixel_sets), *list(pixel_sets)])
+        zip_archive = self._export_pixelsets(
+            [*list(pixel_sets), *list(pixel_sets)]
+        )
         self._assert_archive_is_valid(zip_archive)
 
         with zip_archive.open(PIXELSET_EXPORT_META_FILENAME) as meta_file:

--- a/apps/explorer/urls.py
+++ b/apps/explorer/urls.py
@@ -8,4 +8,9 @@ urlpatterns = [
         views.PixelSetListView.as_view(),
         name='pixelset_list'
     ),
+    url(
+        r'^pixelset/export$',
+        views.PixelSetExportView.as_view(),
+        name='pixelset_export'
+    ),
 ]

--- a/apps/explorer/utils/export.py
+++ b/apps/explorer/utils/export.py
@@ -24,8 +24,8 @@ def export_pixelsets(pixel_sets):
 
     Returns
     -------
-    zipfile.ZipFile
-        A ZipFile archive.
+    io.BytesIO
+        A Binary I/O containing the ZIP archive.
 
     """
 
@@ -65,8 +65,9 @@ def export_pixelsets(pixel_sets):
             ] = pixel.quality_score
 
     # create in-memory archive
+    stream = BytesIO()
     archive = zipfile.ZipFile(
-        BytesIO(),
+        stream,
         mode='w',
         compression=zipfile.ZIP_DEFLATED
     )
@@ -87,4 +88,6 @@ def export_pixelsets(pixel_sets):
     # add `pixels.csv` file
     archive.writestr(PIXELSET_EXPORT_PIXELS_FILENAME, csv.getvalue())
 
-    return archive
+    archive.close()
+
+    return stream

--- a/apps/explorer/views.py
+++ b/apps/explorer/views.py
@@ -96,6 +96,7 @@ class PixelSetListView(LoginRequiredMixin, FormMixin, ListView):
 
 
 class PixelSetExportView(LoginRequiredMixin, FormView):
+    ATTACHEMENT_FILENAME = 'pixelsets.zip'
 
     form_class = PixelSetExportForm
 
@@ -104,7 +105,9 @@ class PixelSetExportView(LoginRequiredMixin, FormView):
         zip = export_pixelsets(form.cleaned_data['pixel_sets'])
 
         response = HttpResponse(zip.getvalue(), content_type='application/zip')
-        response['Content-Disposition'] = 'attachment; filename=pixelsets.zip'
+        response['Content-Disposition'] = 'attachment; filename={}'.format(
+            self.ATTACHEMENT_FILENAME
+        )
         return response
 
     def form_invalid(self, form):

--- a/apps/explorer/views.py
+++ b/apps/explorer/views.py
@@ -101,8 +101,9 @@ class PixelSetExportView(LoginRequiredMixin, FormView):
 
     form_class = PixelSetExportForm
 
-    def _get_export_archive_filename(self):
-        return self.ATTACHEMENT_FILENAME.format(
+    @staticmethod
+    def get_export_archive_filename():
+        return PixelSetExportView.ATTACHEMENT_FILENAME.format(
             date_time=timezone.now().strftime('%Y%m%d_%Hh%Mm%Ss')
         )
 
@@ -112,7 +113,7 @@ class PixelSetExportView(LoginRequiredMixin, FormView):
 
         response = HttpResponse(content, content_type='application/zip')
         response['Content-Disposition'] = 'attachment; filename={}'.format(
-            self._get_export_archive_filename()
+            self.get_export_archive_filename()
         )
         return response
 

--- a/assets/scss/_explorer.scss
+++ b/assets/scss/_explorer.scss
@@ -50,6 +50,10 @@
 
       width: 200%;
 
+      .pixelset {
+        cursor: pointer;
+      }
+
       td {
         vertical-align: top;
       }

--- a/assets/scss/_explorer.scss
+++ b/assets/scss/_explorer.scss
@@ -40,28 +40,38 @@
   main.content {
     @include xy-cell($size: 9.5, $gutter-position: 'left');
 
+    .pixelsets-wrapper {
+      @include table-scroll;
+    }
+
     table.pixelsets {
       @include table;
       @include table-hover;
 
+      width: 200%;
+
       td {
         vertical-align: top;
-
-        &.filename {
-          font-family: $font-family-monospace;
-        }
-
-        &.analysis,
-        &.experiments {
-          font-size: 0.8rem;
-        }
-
-        span {
-          &.species {
-            font-style: italic;
-          }
-        }
       }
+
+      .filename {
+        font-family: $font-family-monospace;
+      }
+
+      .analysis,
+      .experiments {
+        font-size: 0.8rem;
+      }
+
+      span.species {
+        font-style: italic;
+      }
+    }
+
+    .actions {
+      margin-bottom: 10px;
+      padding: 20px 20px 5px;
+      text-align: center;
     }
   }
 }


### PR DESCRIPTION
This PR adds a new button to the pixel set listing page in order to export
selected pixel sets as a ZIP file. At least one pixel set must be selected.