### PR TITLE
Add pixelset detail view

### DIFF
--- a/apps/core/models.py
+++ b/apps/core/models.py
@@ -4,6 +4,7 @@ import mptt
 from django.contrib.auth.models import AbstractUser
 from django.conf import settings
 from django.db import models
+from django.urls import reverse
 from django.utils.translation import ugettext as _
 from mptt.fields import TreeForeignKey
 from mptt.models import MPTTModel
@@ -239,6 +240,12 @@ class PixelSet(UUIDModelMixin, models.Model):
         ordering = ('analysis', 'pixels_file')
         verbose_name = _("Pixel set")
         verbose_name_plural = _("Pixel sets")
+
+    def get_absolute_url(self):
+        return reverse(
+            'explorer:pixelset_detail',
+            kwargs={'pk': str(self.id)}
+        )
 
     def get_omics_areas(self):
         return set(self.analysis.experiments.values_list(

--- a/apps/explorer/templates/explorer/pixelset_detail.html
+++ b/apps/explorer/templates/explorer/pixelset_detail.html
@@ -2,6 +2,7 @@
 
 {% load i18n %}
 {% load files %}
+{% load spurl %}
 
 {% block title %}{% trans "Pixel set" %} {{ pixelset.id }}{% endblock %}
 {% block body_class %}{{ block.super }} explorer pixelset detail{% endblock %}
@@ -101,12 +102,17 @@
             <th>{% trans "Tags" %}</th>
             <td class="tags">
               <!-- Tags -->
+              {% url 'explorer:pixelset_list' as pixelset_list_base_url %}
               {% for tag in pixelset.analysis.tags.all %}
-                <span class="tag analysis">{{ tag }}</span>
+                <a href="{% spurl base=pixelset_list_base_url set_query="tags={{ tag.id }}" %}">
+                  <span class="tag analysis">{{ tag }}</span>
+                </a>
               {% endfor %}
               {% for experiment in pixelset.analysis.experiments.all %}
                 {% for tag in experiment.tags.all %}
-                  <span class="tag experiment">{{ tag }}</span>
+                  <a href="{% spurl base=pixelset_list_base_url set_query="tags={{ tag.id }}" %}">
+                    <span class="tag experiment">{{ tag }}</span>
+                  </a>
                 {% endfor %}
               {% endfor %}
             </td>

--- a/apps/explorer/templates/explorer/pixelset_detail.html
+++ b/apps/explorer/templates/explorer/pixelset_detail.html
@@ -9,20 +9,196 @@
 {% block header %}
 <h1>
   {% trans "Pixel set" %}
+  <span class="subheader">
+    {{ pixelset.get_short_uuid }}
+  </span>
 </h1>
-<span class="subheader">
-  {{ pixelset.id }}
-</span>
+
 {% endblock %}
 
 
 {% block content %}
 
-  Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
-  tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
-  quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
-  consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
-  cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
-  proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+  <section class="pixelset-overview">
+    <div class="meta">
+      <h4>{% trans "Properties" %}</h4>
 
+      <table>
+        <tbody>
+          <tr>
+            <th>{% trans "ID" %}</th>
+            <td>
+              <!-- ID -->
+              {{ pixelset.id }}
+            </td>
+          </tr>
+          <tr>
+            <th>{% trans "Filename" %}</th>
+            <td class="filename">
+              <!-- Pixel set file name -->
+              {{ pixelset.pixels_file.name|filename }}
+              <a
+                href="{{ pixelset.pixels_file.url }}"
+                title="{% trans "Download original data" %}"
+              >
+                <i class="fa fa-download" aria-hidden="true"></i>
+              </a>
+            </td>
+          </tr>
+          <tr>
+            <th>{% trans "Species" %}</th>
+            <td class="species">
+              <!-- Species-->
+              {% for species in pixelset.get_species %}
+                <span class="species">{{ species }}</span>
+              {% endfor %}
+            </td>
+          </tr>
+          <tr>
+            <th>{% trans "Omics Unit types" %}</th>
+            <td class="omics-unit-types">
+              <!-- Omics Unit Type -->
+              {% for type in pixelset.get_omics_unit_types %}
+                <span class="omics-unit-type">{{ type }}</span>
+              {% endfor %}
+            </td>
+          </tr>
+          <tr>
+            <th>{% trans "Omics Areas" %}</th>
+            <td class="omics-areas">
+              <!-- Omics Area -->
+              {% for area in pixelset.get_omics_areas %}
+                <span class="omics-area">{{ area }}</span>
+              {% endfor %}
+            </td>
+          </tr>
+          <tr>
+            <th>{% trans "Pixeler" %}</th>
+            <td class="pixeler">
+              <!-- Pixeler -->
+              {{ pixelset.analysis.pixeler.get_full_name }}
+            </td>
+          </tr>
+          <tr>
+            <th>{% trans "Analysis" %}</th>
+            <td class="analysis">
+              <!-- Analysis -->
+              {{ pixelset.analysis.description }}
+            </td>
+          </tr>
+          <tr>
+            <th>{% trans "Experiments" %}</th>
+            <td class="experiments">
+              <!-- Experiment -->
+              {% for experiment in pixelset.analysis.experiments.all %}
+                <span class="experiment">
+                  {{ experiment.description }}
+                </span>
+              {% endfor %}
+            </td>
+          </tr>
+          <tr>
+            <th>{% trans "Tags" %}</th>
+            <td class="tags">
+              <!-- Tags -->
+              {% for tag in pixelset.analysis.tags.all %}
+                <span class="tag analysis">{{ tag }}</span>
+              {% endfor %}
+              {% for experiment in pixelset.analysis.experiments.all %}
+                {% for tag in experiment.tags.all %}
+                  <span class="tag experiment">{{ tag }}</span>
+                {% endfor %}
+              {% endfor %}
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <div class="selection">
+      <h4>{% trans "Subset selection" %}</h4>
+
+      <p>
+        {% blocktrans %}
+          Copy/paste a list of omics units to select a subset of pixels in this
+          pixel set. You'll be able to export them further.
+        {% endblocktrans %}
+      </p>
+
+      <form action="" method="post" id="pixel-selection-form">
+        {% csrf_token %}
+
+        <label>
+          Omics units
+          <textarea
+            name="omics_units"
+            placeholder="CAGL0F02695g, CAGL0D06336g, CAGL0G06666g"
+          ></textarea>
+        </label>
+        <p class="help-text">
+          {% blocktrans %}
+            Type omics units separated by a coma, a carriage return or a space
+          {% endblocktrans %}
+        </p>
+        <button type="submit" name="select" class="button">{% trans "Select" %}</button>
+      </form>
+
+      <hr>
+
+      <p>
+        {% blocktrans with selected=pixelset.pixels.count total=pixelset.pixels.count %}
+          You have selected
+          <span class="badge success">{{ selected }}</span> pixels
+          among a grand total of
+          <span class="badge secondary">{{ total }}</span> pixels.
+        {% endblocktrans %}
+      </p>
+
+    </div>
+  </section>
+
+  <section class="pixels-wrapper">
+    <h4>
+      {% trans "Pixels" %}
+      <span class="subheader">
+        {{ pixelset.pixels.count }}
+      </span>
+    </h4>
+
+    <table class="pixels">
+      <thead>
+        <tr>
+          <th>{% trans "Omics Unit" %}</th>
+          <th>{% trans "Value" %}</th>
+          <th>{% trans "Quality score" %}</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for pixel in pixelset.pixels.all %}
+          <tr class="pixel">
+            <td class="omics-unit">
+              <a
+                href="{{ pixel.omics_unit.reference.url }}"
+                title="{% trans "Check out omics unit reference" %}"
+              >
+                {{ pixel.omics_unit.reference.identifier }}
+              </a>
+            </td>
+            <td class="value">
+              {{ pixel.value }}
+            </td>
+            <td class="quality-score">
+              {{ pixel.quality_score }}
+            </td>
+          </tr>
+        {% empty %}
+          <tr>
+            <td colspan="3" class="empty">
+              {% trans "This pixelset has no pixels (or your selection gave no results)" %}
+            </td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </section>
 {% endblock content %}

--- a/apps/explorer/templates/explorer/pixelset_detail.html
+++ b/apps/explorer/templates/explorer/pixelset_detail.html
@@ -132,6 +132,7 @@
           Omics units
           <textarea
             name="omics_units"
+            rows="15"
             placeholder="CAGL0F02695g, CAGL0D06336g, CAGL0G06666g"
           ></textarea>
         </label>
@@ -140,7 +141,14 @@
             Type omics units separated by a coma, a carriage return or a space
           {% endblocktrans %}
         </p>
-        <button type="submit" name="select" class="button">{% trans "Select" %}</button>
+        <button
+          type="submit"
+          name="select"
+          class="button"
+          disabled
+        >
+          {% trans "Select" %}
+        </button>
       </form>
 
       <hr>
@@ -165,6 +173,13 @@
       </span>
     </h4>
 
+    <div class="callout secondary">
+      {% blocktrans %}
+        The following table is an overview of pixels from the pixel set. Only
+        the first <strong>{{ pixels_limit }}</strong> are showned.
+      {% endblocktrans %}
+    </div>
+
     <table class="pixels">
       <thead>
         <tr>
@@ -174,7 +189,7 @@
         </tr>
       </thead>
       <tbody>
-        {% for pixel in pixelset.pixels.all %}
+        {% for pixel in pixels %}
           <tr class="pixel">
             <td class="omics-unit">
               <a

--- a/apps/explorer/templates/explorer/pixelset_detail.html
+++ b/apps/explorer/templates/explorer/pixelset_detail.html
@@ -1,0 +1,28 @@
+{% extends "base.html" %}
+
+{% load i18n %}
+{% load files %}
+
+{% block title %}{% trans "Pixel set" %} {{ pixelset.id }}{% endblock %}
+{% block body_class %}{{ block.super }} explorer pixelset detail{% endblock %}
+
+{% block header %}
+<h1>
+  {% trans "Pixel set" %}
+</h1>
+<span class="subheader">
+  {{ pixelset.id }}
+</span>
+{% endblock %}
+
+
+{% block content %}
+
+  Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+  tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+  quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+  consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+  cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
+  proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+{% endblock content %}

--- a/apps/explorer/templates/explorer/pixelset_detail.html
+++ b/apps/explorer/templates/explorer/pixelset_detail.html
@@ -176,7 +176,7 @@
     <div class="callout secondary">
       {% blocktrans %}
         The following table is an overview of pixels from the pixel set. Only
-        the first <strong>{{ pixels_limit }}</strong> are showned.
+        the first <strong>{{ pixels_limit }}</strong> are shown.
       {% endblocktrans %}
     </div>
 

--- a/apps/explorer/templates/explorer/pixelset_list.html
+++ b/apps/explorer/templates/explorer/pixelset_list.html
@@ -64,7 +64,12 @@
             </td>
             <td class="filename">
               <!-- Pixel set file name -->
-              {{ pixelset.pixels_file.name|filename }}
+              <a
+                href="{{ pixelset.get_absolute_url }}"
+                title="{% trans "Click for details about this pixel set" %}"
+              >
+                {{ pixelset.pixels_file.name|filename }}
+              </a>
             </td>
             <td class="species">
               <!-- Species-->

--- a/apps/explorer/tests/test_views.py
+++ b/apps/explorer/tests/test_views.py
@@ -417,11 +417,13 @@ class PixelSetListViewTestCase(CoreFixturesTestCase):
             response,
             (
                 '<td class="filename">'
+                '<a'
+                f'  href="{pixel_set.get_absolute_url()}"'
+                '  title="Click for details about this pixel set"'
+                '>'
                 '<!-- Pixel set file name -->'
-                '{}'
+                f'{filename(pixel_set.pixels_file.name)}'
                 '</td>'
-            ).format(
-                filename(pixel_set.pixels_file.name)
             ),
             count=1,
             html=True,
@@ -487,6 +489,10 @@ class PixelSetListViewTestCase(CoreFixturesTestCase):
             response,
             (
                 '<td class="filename">'
+                '<a'
+                f'  href="{first_pixel_set.get_absolute_url()}"'
+                '  title="Click for details about this pixel set"'
+                '>'
                 '<!-- Pixel set file name -->'
                 f'{filename(first_pixel_set.pixels_file.name)}'
                 '</td>'
@@ -498,6 +504,10 @@ class PixelSetListViewTestCase(CoreFixturesTestCase):
             response,
             (
                 '<td class="filename">'
+                '<a'
+                f'  href="{second_pixel_set.get_absolute_url()}"'
+                '  title="Click for details about this pixel set"'
+                '>'
                 '<!-- Pixel set file name -->'
                 f'{filename(second_pixel_set.pixels_file.name)}'
                 '</td>'

--- a/apps/explorer/tests/test_views.py
+++ b/apps/explorer/tests/test_views.py
@@ -423,6 +423,7 @@ class PixelSetListViewTestCase(CoreFixturesTestCase):
                 '>'
                 '<!-- Pixel set file name -->'
                 f'{filename(pixel_set.pixels_file.name)}'
+                '</a>'
                 '</td>'
             ),
             count=1,
@@ -495,6 +496,7 @@ class PixelSetListViewTestCase(CoreFixturesTestCase):
                 '>'
                 '<!-- Pixel set file name -->'
                 f'{filename(first_pixel_set.pixels_file.name)}'
+                '</a>'
                 '</td>'
             ),
             count=1,
@@ -510,6 +512,7 @@ class PixelSetListViewTestCase(CoreFixturesTestCase):
                 '>'
                 '<!-- Pixel set file name -->'
                 f'{filename(second_pixel_set.pixels_file.name)}'
+                '</a>'
                 '</td>'
             ),
             count=1,

--- a/apps/explorer/urls.py
+++ b/apps/explorer/urls.py
@@ -2,11 +2,24 @@ from django.conf.urls import url
 
 from . import views
 
+UUID_REGEX = (
+    '[a-f0-9]{8}-?'
+    '[a-f0-9]{4}-?'
+    '4[a-f0-9]{3}-?'
+    '[89ab][a-f0-9]{3}-?'
+    '[a-f0-9]{12}'
+)
+
 urlpatterns = [
     url(
         r'^pixelset/$',
         views.PixelSetListView.as_view(),
         name='pixelset_list'
+    ),
+    url(
+        r'^pixelset/(?P<pk>{})/$'.format(UUID_REGEX),
+        views.PixelSetDetailView.as_view(),
+        name='pixelset_detail'
     ),
     url(
         r'^pixelset/export$',

--- a/apps/explorer/views.py
+++ b/apps/explorer/views.py
@@ -137,18 +137,18 @@ class PixelSetDetailView(LoginRequiredMixin, DetailView):
 
     model = PixelSet
     template_name = 'explorer/pixelset_detail.html'
+    pixels_limit = 100
 
     def get_context_data(self, **kwargs):
 
         context = super().get_context_data(**kwargs)
 
-        pixels_limit = 100
         pixels = self.object.pixels.prefetch_related(
             'omics_unit__reference'
-        )[:pixels_limit]
+        )[:self.pixels_limit]
 
         context.update({
             'pixels': pixels,
-            'pixels_limit': pixels_limit,
+            'pixels_limit': self.pixels_limit,
         })
         return context

--- a/apps/explorer/views.py
+++ b/apps/explorer/views.py
@@ -4,7 +4,7 @@ from django.contrib.auth.mixins import LoginRequiredMixin
 from django.http import HttpResponse, HttpResponseRedirect
 from django.urls.base import reverse
 from django.utils import timezone
-from django.views.generic import ListView, FormView
+from django.views.generic import DetailView, FormView, ListView
 from django.views.generic.edit import FormMixin
 
 from apps.core.models import PixelSet
@@ -131,3 +131,9 @@ class PixelSetExportView(LoginRequiredMixin, FormView):
             reverse('explorer:pixelset_list')
         )
         return HttpResponseRedirect(redirect_to)
+
+
+class PixelSetDetailView(LoginRequiredMixin, DetailView):
+
+    model = PixelSet
+    template_name = 'explorer/pixelset_detail.html'

--- a/apps/explorer/views.py
+++ b/apps/explorer/views.py
@@ -137,3 +137,18 @@ class PixelSetDetailView(LoginRequiredMixin, DetailView):
 
     model = PixelSet
     template_name = 'explorer/pixelset_detail.html'
+
+    def get_context_data(self, **kwargs):
+
+        context = super().get_context_data(**kwargs)
+
+        pixels_limit = 100
+        pixels = self.object.pixels.prefetch_related(
+            'omics_unit__reference'
+        )[:pixels_limit]
+
+        context.update({
+            'pixels': pixels,
+            'pixels_limit': pixels_limit,
+        })
+        return context

--- a/assets/scss/_commons.scss
+++ b/assets/scss/_commons.scss
@@ -29,14 +29,6 @@ form {
             color: $alert-color;
           }
         }
-
-        input {
-          margin-bottom: 0.2rem;
-        }
-      }
-
-      p.help-text {
-        margin-top: 0;
       }
     }
   }

--- a/assets/scss/_explorer.scss
+++ b/assets/scss/_explorer.scss
@@ -1,7 +1,36 @@
 .explorer {
 
+  /* layout */
+  &.pixelsets {
+    aside.sidebar-left {
+      @include xy-cell($size: 2.5, $gutter-output: false);
+    }
+
+    main.content {
+      @include xy-cell($size: 9.5, $gutter-position: 'left');
+    }
+  }
+
+  &.pixelset {
+    main.content {
+      @include xy-cell($size: 12, $gutter-output: false);
+
+      .pixelset-overview {
+        @include xy-grid($wrap: false);
+
+        .meta {
+          @include xy-cell($size: 6, $gutter-output: false);
+        }
+
+        .selection {
+          @include xy-cell($size: 6, $gutter-position: 'left');
+        }
+      }
+    }
+  }
+
+  /* pixelset list */
   aside.sidebar-left {
-    @include xy-cell($size: 2.5, $gutter-output: false);
 
     .filters {
 
@@ -37,45 +66,68 @@
     }
   }
 
-  main.content {
-    @include xy-cell($size: 9.5, $gutter-position: 'left');
+  .pixelsets-wrapper {
+    @include table-scroll;
+  }
 
-    .pixelsets-wrapper {
-      @include table-scroll;
+  table {
+    @include table;
+    @include table-hover;
+
+    .pixelset {
+      cursor: pointer;
     }
 
-    table.pixelsets {
-      @include table;
-      @include table-hover;
+    td {
+      vertical-align: top;
+    }
 
-      width: 200%;
+    .filename {
+      font-family: $font-family-monospace;
+    }
 
-      .pixelset {
-        cursor: pointer;
-      }
+    .analysis,
+    .experiments {
+      font-size: 0.8rem;
+    }
 
-      td {
-        vertical-align: top;
-      }
+    span.species {
+      font-style: italic;
+    }
+  }
 
-      .filename {
-        font-family: $font-family-monospace;
-      }
+  .actions {
+    margin-bottom: 10px;
+    padding: 20px 20px 5px;
+    text-align: center;
+  }
 
-      .analysis,
-      .experiments {
-        font-size: 0.8rem;
-      }
+  table.pixelsets {
+    width: 200%;
+  }
 
-      span.species {
-        font-style: italic;
+  /* pixel set detail */
+  .pixelset-overview {
+
+    .meta {
+      table {
+        th {
+          text-align: left;
+        }
       }
     }
 
-    .actions {
-      margin-bottom: 10px;
-      padding: 20px 20px 5px;
-      text-align: center;
+    .selection {
+      p.help-text {
+        margin-top: 0.4rem;
+      }
+    }
+  }
+
+  table.pixels {
+    .value,
+    .quality-score {
+      font-family: $font-family-monospace;
     }
   }
 }

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -10,6 +10,7 @@
 
 $global-flexbox: true;
 
+@include foundation-badge;
 @include foundation-button;
 @include foundation-callout;
 @include foundation-forms;


### PR DESCRIPTION
## Purpose

One need to explore a particular pixel set.

## Proposal

This PR makes pixel set filename clickable in the pixel set list view and implements a pixel set detail view. 

### Noticeable features

* Original pixel set file is downloadable
* Pixel set tags are clickable and lead to a pixel set list view filtered by the clicked tag
* Omics Units in pixels table are clickable too (direct link to the original repository)

### Remark

For performance purpose, we have limited the number of pixels to display to an arbitrary value of `100`. I might be wrong but I have the feeling that end users will not check values pixel per pixel on a web page, hence there is no need to display all pixels. Am I right?

## Sneak peek

![screenshot-2018-1-26 pixel set f681d6c8-602e-451c-a4a2-5c0b49f97565](https://user-images.githubusercontent.com/956157/35445328-9a0e1c8e-02b1-11e8-8f79-9ccd7bd0b332.png)
