### PR TITLE
Add edition links to the pixel set detail view

### DIFF
--- a/apps/explorer/templates/explorer/pixelset_detail.html
+++ b/apps/explorer/templates/explorer/pixelset_detail.html
@@ -15,6 +15,16 @@
   </span>
 </h1>
 
+{% if request.user.is_staff %}
+<a
+  href="{% url 'admin:core_pixelset_change' pixelset.id %}"
+  title="{% trans "Edit this pixel set from the admin" %}"
+  class="edit"
+>
+  <i class="fa fa-pencil" aria-hidden="true"></i>
+  {% trans "edit" %}
+</a>
+{% endif %}
 {% endblock %}
 
 
@@ -85,6 +95,17 @@
             <td class="analysis">
               <!-- Analysis -->
               {{ pixelset.analysis.description }}
+
+              {% if request.user.is_staff %}
+              <a
+                href="{% url 'admin:core_analysis_change' pixelset.analysis.id %}"
+                title="{% trans "Edit this analysis from the admin" %}"
+                class="edit"
+              >
+                <i class="fa fa-pencil" aria-hidden="true"></i>
+                {% trans "edit" %}
+              </a>
+              {% endif %}
             </td>
           </tr>
           <tr>
@@ -95,6 +116,17 @@
                 <span class="experiment">
                   {{ experiment.description }}
                 </span>
+
+                {% if request.user.is_staff %}
+                <a
+                  href="{% url 'admin:core_experiment_change' experiment.id %}"
+                  title="{% trans "Edit this experiment from the admin" %}"
+                  class="edit"
+                >
+                  <i class="fa fa-pencil" aria-hidden="true"></i>
+                  {% trans "edit" %}
+                </a>
+                {% endif %}
               {% endfor %}
             </td>
           </tr>

--- a/apps/explorer/tests/test_views.py
+++ b/apps/explorer/tests/test_views.py
@@ -902,6 +902,61 @@ class PixelSetDetailViewTestCase(CoreFixturesTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, 'explorer/pixelset_detail.html')
 
+    def test_shows_edition_link_for_staff_users(self):
+
+        response = self.client.get(self.url)
+
+        admin_url = reverse(
+            'admin:core_pixelset_change',
+            args=(str(self.pixel_set.id), )
+        )
+        title = 'Edit this pixel set from the admin'
+        expected = (
+            f'<a href="{admin_url}" title="{title}" class="edit">'
+            '<i class="fa fa-pencil" aria-hidden="true"></i>'
+            'edit'
+            '</a>'
+        )
+        self.assertContains(
+            response,
+            expected,
+            html=True,
+            count=1
+        )
+
+    def test_hides_edition_link_for_standard_users(self):
+
+        self.client.logout()
+
+        user = factories.PixelerFactory(
+            is_active=True,
+            is_staff=False,
+            is_superuser=False,
+        )
+        self.client.login(
+            username=user.username,
+            password=factories.PIXELER_PASSWORD,
+        )
+
+        response = self.client.get(self.url)
+
+        admin_url = reverse(
+            'admin:core_pixelset_change',
+            args=(str(self.pixel_set.id), )
+        )
+        title = 'Edit this pixel set from the admin'
+        expected = (
+            f'<a href="{admin_url}" title="{title}" class="edit">'
+            '<i class="fa fa-pencil" aria-hidden="true"></i>'
+            'edit'
+            '</a>'
+        )
+        self.assertNotContains(
+            response,
+            expected,
+            html=True,
+        )
+
     def test_show_description_in_pixels_preview(self):
 
         response = self.client.get(self.url)


### PR DESCRIPTION
## Purpose

Fix #183 by adding edition links for **admin users only**.

## Sneak peek

 
![screenshot-2018-1-29 pixel set 77e9c609-f2c5-4d6b-9aed-01b4e91ddd66 2](https://user-images.githubusercontent.com/956157/35537168-94245dd4-0549-11e8-9fe5-ad17449e50f7.png)
