### PR TITLE
Add histogram for values and quality scores on the pixel set detail view

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -20,6 +20,7 @@ pandas = "*"
 background = "*"
 django-spurl = "*"
 pyyaml = "*"
+gviz_api = "*"
 
 
 [dev-packages]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,18 +1,18 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "1800b4187f374a64a4558bf7d4b830aa0864d3b1f8074736ad2c12056edc8da2"
+            "sha256": "de7dafc07244e75a29892e0aece2b73887938b0856c9da2ace9afa4a5e078d9e"
         },
         "host-environment-markers": {
             "implementation_name": "cpython",
-            "implementation_version": "3.6.3",
+            "implementation_version": "3.6.4",
             "os_name": "posix",
             "platform_machine": "x86_64",
             "platform_python_implementation": "CPython",
             "platform_release": "4.9.75-linuxkit-aufs",
             "platform_system": "Linux",
             "platform_version": "#1 SMP Tue Jan 9 10:58:17 UTC 2018",
-            "python_full_version": "3.6.3",
+            "python_full_version": "3.6.4",
             "python_version": "3.6",
             "sys_platform": "linux"
         },
@@ -38,10 +38,10 @@
         },
         "django": {
             "hashes": [
-                "sha256:90952c46d2b7b042db00e98b05f5dd97a5775822948d46fd82ff074d8ac75853",
-                "sha256:353d129f22e1d24980d6061666f435781141c2dfd852f14ffc8a670175821034"
+                "sha256:ac4c797a328a5ac8777ad61bcd00da279773455cc78b4058de2a9842a0eb6ee8",
+                "sha256:22383567385a9c406d8a5ce080a2694c82c6b733e157922197e8b393bb3aacd9"
             ],
-            "version": "==1.11.9"
+            "version": "==1.11.10"
         },
         "django-configurations": {
             "hashes": [
@@ -118,6 +118,13 @@
                 "sha256:eee1169f0ca667be05db3351a0960765620dad53f53434262ff8901b68a1b622"
             ],
             "version": "==19.7.1"
+        },
+        "gviz-api": {
+            "hashes": [
+                "sha256:4f1edcc54443e67c5699c6962ce9bb8bb9289551e918db6f6f8ed74b53294ff9",
+                "sha256:43d13ccc21834d0501b33a291ef3265e933dbb4bbdca3d34b1ed0a048c0ef640"
+            ],
+            "version": "==1.9.0"
         },
         "jdcal": {
             "hashes": [
@@ -301,48 +308,44 @@
         },
         "coverage": {
             "hashes": [
-                "sha256:d1ee76f560c3c3e8faada866a07a32485445e16ed2206ac8378bd90dadffb9f0",
-                "sha256:007eeef7e23f9473622f7d94a3e029a45d55a92a1f083f0f3512f5ab9a669b05",
-                "sha256:17307429935f96c986a1b1674f78079528833410750321d22b5fb35d1883828e",
-                "sha256:845fddf89dca1e94abe168760a38271abfc2e31863fbb4ada7f9a99337d7c3dc",
-                "sha256:3f4d0b3403d3e110d2588c275540649b1841725f5a11a7162620224155d00ba2",
-                "sha256:4c4f368ffe1c2e7602359c2c50233269f3abe1c48ca6b288dcd0fb1d1c679733",
-                "sha256:f8c55dd0f56d3d618dfacf129e010cbe5d5f94b6951c1b2f13ab1a2f79c284da",
-                "sha256:cdd92dd9471e624cd1d8c1a2703d25f114b59b736b0f1f659a98414e535ffb3d",
-                "sha256:2ad357d12971e77360034c1596011a03f50c0f9e1ecd12e081342b8d1aee2236",
-                "sha256:e9a0e1caed2a52f15c96507ab78a48f346c05681a49c5b003172f8073da6aa6b",
-                "sha256:eea9135432428d3ca7ee9be86af27cb8e56243f73764a9b6c3e0bda1394916be",
-                "sha256:700d7579995044dc724847560b78ac786f0ca292867447afda7727a6fbaa082e",
-                "sha256:66f393e10dd866be267deb3feca39babba08ae13763e0fc7a1063cbe1f8e49f6",
-                "sha256:5ff16548492e8a12e65ff3d55857ccd818584ed587a6c2898a9ebbe09a880674",
-                "sha256:d00e29b78ff610d300b2c37049a41234d48ea4f2d2581759ebcf67caaf731c31",
-                "sha256:87d942863fe74b1c3be83a045996addf1639218c2cb89c5da18c06c0fe3917ea",
-                "sha256:358d635b1fc22a425444d52f26287ae5aea9e96e254ff3c59c407426f44574f4",
-                "sha256:81912cfe276e0069dca99e1e4e6be7b06b5fc8342641c6b472cb2fed7de7ae18",
-                "sha256:079248312838c4c8f3494934ab7382a42d42d5f365f0cf7516f938dbb3f53f3f",
-                "sha256:b0059630ca5c6b297690a6bf57bf2fdac1395c24b7935fd73ee64190276b743b",
-                "sha256:493082f104b5ca920e97a485913de254cbe351900deed72d4264571c73464cd0",
-                "sha256:e3ba9b14607c23623cf38f90b23f5bed4a3be87cbfa96e2e9f4eabb975d1e98b",
-                "sha256:82cbd3317320aa63c65555aa4894bf33a13fb3a77f079059eb5935eea415938d",
-                "sha256:9721f1b7275d3112dc7ccf63f0553c769f09b5c25a26ee45872c7f5c09edf6c1",
-                "sha256:bd4800e32b4c8d99c3a2c943f1ac430cbf80658d884123d19639bcde90dad44a",
-                "sha256:f29841e865590af72c4b90d7b5b8e93fd560f5dea436c1d5ee8053788f9285de",
-                "sha256:f3a5c6d054c531536a83521c00e5d4004f1e126e2e2556ce399bef4180fbe540",
-                "sha256:dd707a21332615108b736ef0b8513d3edaf12d2a7d5fc26cd04a169a8ae9b526",
-                "sha256:2e1a5c6adebb93c3b175103c2f855eda957283c10cf937d791d81bef8872d6ca",
-                "sha256:f87f522bde5540d8a4b11df80058281ac38c44b13ce29ced1e294963dd51a8f8",
-                "sha256:a7cfaebd8f24c2b537fa6a271229b051cdac9c1734bb6f939ccfc7c055689baa",
-                "sha256:309d91bd7a35063ec7a0e4d75645488bfab3f0b66373e7722f23da7f5b0f34cc",
-                "sha256:0388c12539372bb92d6dde68b4627f0300d948965bbb7fc104924d715fdc0965",
-                "sha256:ab3508df9a92c1d3362343d235420d08e2662969b83134f8a97dc1451cbe5e84",
-                "sha256:43a155eb76025c61fc20c3d03b89ca28efa6f5be572ab6110b2fb68eda96bfea",
-                "sha256:f98b461cb59f117887aa634a66022c0bd394278245ed51189f63a036516e32de",
-                "sha256:b6cebae1502ce5b87d7c6f532fa90ab345cfbda62b95aeea4e431e164d498a3d",
-                "sha256:a4497faa4f1c0fc365ba05eaecfb6b5d24e3c8c72e95938f9524e29dadb15e76",
-                "sha256:2b4d7f03a8a6632598cbc5df15bbca9f778c43db7cf1a838f4fa2c8599a8691a",
-                "sha256:1afccd7e27cac1b9617be8c769f6d8a6d363699c9b86820f40c74cfb3328921c"
+                "sha256:464d85d6959497cc4adfa9f0d36fca809e2ca7ec5f4625f548317892cac6ed7c",
+                "sha256:e958ab5b6a7f3b88289a25c95d031f2b62bc73219141c09d261fd97f244c124c",
+                "sha256:67288f8834a0a64c1af66286b22fd325b5524ceaa153a51c3e2e30f7e8b3f826",
+                "sha256:cfb6b7035c6605e2a87abe7d84ea35a107e6c432014a3f1ca243ab57a558fbcd",
+                "sha256:c86a12b3dc004bcbe97a3849354bd1f93eb6fb69b0e4eb58831fd7adba7740ec",
+                "sha256:8ddcf308f894d01a1a0ae01283d19b613751815b7190113266a0b7f9d076e86d",
+                "sha256:adab01e4c63a01bdf036f57f0114497994aa2195d8659d12a3d69673c3f27939",
+                "sha256:54d73fe68a7ac9c847af69a234a7461bbaf3cad95f258317d4584d14dd53f679",
+                "sha256:a0d98c71d026c1757c7393a99d24c6e42091ff41e20e68238b17e145252c2d0a",
+                "sha256:464e0eda175c7fe2dc730d9d02acde5b8a8518d9417413dee6ca187d1f65ef89",
+                "sha256:2890cb40464686c0c1dccc1223664bbc34d85af053bc5dbcd71ea13959e264f2",
+                "sha256:0f2315c793b1360f80a9119fff76efb7b4e5ab5062651dff515e681719f29689",
+                "sha256:85c028e959312285225040cdac5ad3db6189e958a234f09ae6b4ba5f539c842d",
+                "sha256:da6585339fc8a25086003a2b2c0167438b8ab0cd0ccae468d22ed603e414bba1",
+                "sha256:e837865a7b20c01a8a2f904c05fba36e8406b146649ff9174cbddf32e217b777",
+                "sha256:b718efb33097c7651a60a03b4b38b14776f92194bc0e9e598ce05ddaef7c70e7",
+                "sha256:7413f078fbba267de44814584593a729f88fc37f2d938263844b7f4daf1e36ec",
+                "sha256:47ad00a0c025f87a7528cc13d013c54e4691ae8730430e49ec9c7ace7e0e1fba",
+                "sha256:95f9f5072afeb2204401401cbd0ab978a9f86ef1ebc5cd267ba431cfa581cc4d",
+                "sha256:ca8827a5dad1176a8da6bf5396fd07e66549d1bc842047b76cdf69e196597a80",
+                "sha256:c68164c4f49cfc2e66ca1ded62e4a1092a6bd4b2c65222059b867700ad19151c",
+                "sha256:61e0bcf15aa0385e15d1fe4a86022a6b813d08c785855e3fab56ba6d7ac3dd21",
+                "sha256:981a64063242a2c6c88dda33ccafe3583026847961fe56636b6a00c47674e258",
+                "sha256:21e47d2ff9c75e25880dd12b316db11379e9afc98b39e9516149d189c15c564b",
+                "sha256:f6b822c68f68f48d480d23fcfcd1d4df7d42ff03cf5d7b574d09e662c0b95b43",
+                "sha256:53fa7aa7643a22eeadcf8b781b97a51f37d43ba1d897a05238aa7e4d11bc0667",
+                "sha256:95ce1a70323d47c0f6b8d6cfd3c14c38cb30d51fd1ab4f6414734fa33a78b17e",
+                "sha256:b7a06a523dfeaf417da630d46ad4f4e11ca1bae6202c9312c4cb987dde5792fc",
+                "sha256:585e8db44b8f3af2a4152b00dd8a7a36bc1d2aba7de5e50fc17a54178428f0d6",
+                "sha256:102933e14b726bd4fdfafb541e122ad36c150732aee36db409d8c8766e11537e",
+                "sha256:15f92238487d93f7f34a3ba03be3bd4615c69cffc88388b4dd1ea99af74fc1bf",
+                "sha256:319190dd7fa08c23332215782b563a9ef12b76fb15e4a325915592b825eca9ed",
+                "sha256:af14e9628c0a3152b6a1fbba4471e6a3e5f5567ecae614f84b84ff3441c58692",
+                "sha256:72bc3f91a25a87fd87eb57983c8cefbb8aa5bacd50d73516ade398271d652d77",
+                "sha256:c3905f10786dcf386f3f6cebe0ae4a36f47e5e256471161fb944ca537e97e928",
+                "sha256:3344079d73a4849341aaaecd9b391141824b8c9a96732fbd6ef95ba9566895d3"
             ],
-            "version": "==4.4.2"
+            "version": "==4.5"
         },
         "coveralls": {
             "hashes": [
@@ -353,10 +356,10 @@
         },
         "django": {
             "hashes": [
-                "sha256:90952c46d2b7b042db00e98b05f5dd97a5775822948d46fd82ff074d8ac75853",
-                "sha256:353d129f22e1d24980d6061666f435781141c2dfd852f14ffc8a670175821034"
+                "sha256:ac4c797a328a5ac8777ad61bcd00da279773455cc78b4058de2a9842a0eb6ee8",
+                "sha256:22383567385a9c406d8a5ce080a2694c82c6b733e157922197e8b393bb3aacd9"
             ],
-            "version": "==1.11.9"
+            "version": "==1.11.10"
         },
         "django-debug-toolbar": {
             "hashes": [
@@ -373,10 +376,10 @@
         },
         "factory-boy": {
             "hashes": [
-                "sha256:b8334bcc3c5b10af9a83ab5b8786f98cb322638dc1e6d320cad01c7f2b420e87",
-                "sha256:340c602f6fed2d8dd160397f28f2c0219e937f0488460450e8e5bf2add020ed6"
+                "sha256:be2abc8092294e4097935a29b4e37f5b9ed3e4205e2e32df215c0315b625995e",
+                "sha256:bd5a096d0f102d79b6c78cef1c8c0b650f2e1a3ecba351c735c6d2df8dabd29c"
             ],
-            "version": "==2.9.2"
+            "version": "==2.10.0"
         },
         "faker": {
             "hashes": [
@@ -435,10 +438,10 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:b84878865558194630c6147f44bdaef27222a9f153bbd4a08908b16bf285e0b1",
-                "sha256:53548280ede7818f4dc2ad96608b9f08ae2cc2ca3874f2ceb6f97e3583f25bc4"
+                "sha256:95fa025cd6deb5d937e04e368a00552332b58cae23f63b76c8c540ff1733ab6d",
+                "sha256:6074ea3b9c999bd6d0df5fa9d12dd95ccd23550df2a582f5f5b848331d2e82ca"
             ],
-            "version": "==3.3.2"
+            "version": "==3.4.0"
         },
         "pytest-cov": {
             "hashes": [

--- a/apps/core/templates/core/home-authenticated.html
+++ b/apps/core/templates/core/home-authenticated.html
@@ -13,26 +13,22 @@
 {% endblock content %}
 
 {% block javascript %}
-  <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
+  <script type="text/javascript" src="//www.gstatic.com/charts/loader.js"></script>
   <script type="text/javascript">
     google.charts.load('current', {'packages':['corechart']});
-    google.charts.setOnLoadCallback(drawChart);
+    google.charts.setOnLoadCallback(drawCharts);
 
-    function drawChart() {
-      var data = google.visualization.arrayToDataTable([
-        ['Species', '# of Pixels'],
-        {% for item in pixels_by_species %}
-        ['{{ item.name }}', {{ item.nb }}],
-        {% endfor %}
-      ]);
-
-      var options = {
-        title: 'Pixels by Species'
-      };
-
-      var chart = new google.visualization.PieChart(document.getElementById('pixels-by-species'));
-
-      chart.draw(data, options);
+    function drawCharts() {
+      var pixelBySpecies = new google.visualization.PieChart(
+        document.getElementById('pixels-by-species')
+      );
+      pixelBySpecies.draw(
+        google.visualization.arrayToDataTable(
+          {{ pixels_by_species.data|safe }},
+          true
+        ),
+        { title: '{{ pixels_by_species.title }}' }
+      );
     }
   </script>
 {% endblock javascript %}

--- a/apps/core/views.py
+++ b/apps/core/views.py
@@ -1,5 +1,7 @@
+from django.utils.translation import ugettext as _
 from django.views.generic import TemplateView
 from django.shortcuts import render
+
 
 from apps.core.models import Pixel
 
@@ -12,17 +14,20 @@ class HomeView(TemplateView):
 
         if request.user.is_authenticated():
             pixels_by_species = Pixel.objects.raw((
-                'SELECT core_species.name AS name, count(core_pixel.id) AS nb,'
+                'SELECT core_species.name AS name, count(*) AS nb,'
                 ' 1 as id'  # this is a hack to overcome Django ORM limitations
-                ' FROM core_pixel, core_species, core_omicsunit, core_strain'
-                ' WHERE omics_unit_id = core_omicsunit.id'
-                ' AND core_omicsunit.strain_id = core_strain.id'
-                ' AND core_strain.species_id = core_species.id'
+                ' FROM core_pixel'
+                ' JOIN core_omicsunit ON omics_unit_id = core_omicsunit.id'
+                ' JOIN core_strain ON core_omicsunit.strain_id = core_strain.id'
+                ' JOIN core_species ON core_strain.species_id = core_species.id'
                 ' GROUP BY core_species.name'
             ))
 
             return render(request, 'core/home-authenticated.html', {
-                'pixels_by_species': pixels_by_species,
+                'pixels_by_species': {
+                    'title': _('Pixels by Species'),
+                    'data': [[row.name, row.nb] for row in pixels_by_species],
+                },
             })
 
         return super().get(request, *args, **kwargs)

--- a/apps/core/views.py
+++ b/apps/core/views.py
@@ -17,9 +17,12 @@ class HomeView(TemplateView):
                 'SELECT core_species.name AS name, count(*) AS nb,'
                 ' 1 as id'  # this is a hack to overcome Django ORM limitations
                 ' FROM core_pixel'
-                ' JOIN core_omicsunit ON omics_unit_id = core_omicsunit.id'
-                ' JOIN core_strain ON core_omicsunit.strain_id = core_strain.id'
-                ' JOIN core_species ON core_strain.species_id = core_species.id'
+                ' JOIN core_omicsunit'
+                '   ON omics_unit_id = core_omicsunit.id'
+                ' JOIN core_strain'
+                '   ON core_omicsunit.strain_id = core_strain.id'
+                ' JOIN core_species'
+                '   ON core_strain.species_id = core_species.id'
                 ' GROUP BY core_species.name'
             ))
 

--- a/apps/explorer/templates/explorer/pixelset_detail.html
+++ b/apps/explorer/templates/explorer/pixelset_detail.html
@@ -122,7 +122,7 @@
             <th>{% trans "Experiments" %}</th>
             <td class="experiments">
               <!-- Experiment -->
-              {% for experiment in pixelset.analysis.experiments.all %}
+              {% for experiment in pixelset_experiments %}
               <p>
                 <span class="experiment">
                   {{ experiment.description }}
@@ -158,13 +158,13 @@
             <td class="tags">
               <!-- Tags -->
               {% url 'explorer:pixelset_list' as pixelset_list_base_url %}
-              {% for tag in pixelset.analysis.tags.all %}
+              {% for tag in pixelset.analysis.tags %}
                 <a href="{% spurl base=pixelset_list_base_url set_query="tags={{ tag.id }}" %}">
                   <span class="tag analysis">{{ tag }}</span>
                 </a>
               {% endfor %}
-              {% for experiment in pixelset.analysis.experiments.all %}
-                {% for tag in experiment.tags.all %}
+              {% for experiment in pixelset_experiments %}
+                {% for tag in experiment.tags %}
                   <a href="{% spurl base=pixelset_list_base_url set_query="tags={{ tag.id }}" %}">
                     <span class="tag experiment">{{ tag }}</span>
                   </a>
@@ -200,7 +200,7 @@
             {% trans "Preview" %}
           </button>
 
-          {% if request.session.export.pixels.omics_units and pixels.count > 0 %}
+          {% if request.session.export.pixels.omics_units and pixels_count > 0 %}
           <a class="button" href="{{ pixelset.get_export_pixels_url }}">
               <i class="fa fa-download" aria-hidden="true"></i>
               {% trans "Download a CSV file with the selected Pixels" %}
@@ -212,14 +212,14 @@
       <hr>
 
       <p>
-        {% blocktrans count selected=pixels.count %}
+        {% blocktrans count selected=pixels_count %}
           You have selected
           <span class="badge success">{{ selected }}</span> pixel
           {% plural %}
           You have selected
           <span class="badge success">{{ selected }}</span> pixels
         {% endblocktrans %}
-        {% blocktrans with total=pixelset.pixels.count %}
+        {% blocktrans with total=total_count %}
           among a grand total of
           <span class="badge secondary">{{ total }}</span> pixels.
         {% endblocktrans %}
@@ -233,7 +233,7 @@
       {% trans "Pixels" %}
     </h4>
 
-    {% if pixels.count >= pixels_limit %}
+    {% if total_count > pixels_limit %}
       <div class="callout secondary">
         {% blocktrans %}
           The following table is an overview of pixels from the Pixel Set. Only

--- a/apps/explorer/templates/explorer/pixelset_detail.html
+++ b/apps/explorer/templates/explorer/pixelset_detail.html
@@ -70,7 +70,7 @@
             </td>
           </tr>
           <tr>
-            <th>{% trans "Omics Unit types" %}</th>
+            <th style="width: 110px">{% trans "Omics Unit types" %}</th>
             <td class="omics-unit-types">
               <!-- Omics Unit Type -->
               {% for type in pixelset.get_omics_unit_types %}

--- a/apps/explorer/templates/explorer/pixelset_detail.html
+++ b/apps/explorer/templates/explorer/pixelset_detail.html
@@ -224,7 +224,28 @@
           <span class="badge secondary">{{ total }}</span> pixels.
         {% endblocktrans %}
       </p>
+    </div>
+  </section>
 
+  <section>
+    <h4>
+      {% trans "Distributions" %}
+    </h4>
+
+    <div class="pixelset-distributions">
+      <div class="histogram" id="values-histogram">
+        <p>
+          <i class="fa fa-refresh fa-spin"></i>
+          {% trans "Loading the histogram for values..." %}
+        </p>
+      </div>
+
+      <div class="histogram" id="scores-histogram">
+        <p>
+          <i class="fa fa-refresh fa-spin"></i>
+          {% trans "Loading the histogram for quality scores..." %}
+        </p>
+      </div>
     </div>
   </section>
 
@@ -283,3 +304,43 @@
     </table>
   </section>
 {% endblock content %}
+
+{% block javascript %}
+  <script src="//www.gstatic.com/charts/loader.js"></script>
+  <script src="//ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
+  <script type="text/javascript">
+    google.charts.load('current', {'packages':['corechart']});
+    google.charts.setOnLoadCallback(drawCharts);
+
+    function drawCharts() {
+      var valuesChart = new google.visualization.Histogram(
+        document.getElementById('values-histogram')
+      );
+      var scoresChart = new google.visualization.Histogram(
+        document.getElementById('scores-histogram')
+      );
+
+      $.get('{% url "explorer:pixelset_detail_values" pixelset.id %}', function (data) {
+        valuesChart.draw(
+          new google.visualization.DataTable(data),
+          {
+            height: 300,
+            legend: { position: 'none' },
+            title: '{% trans "Values" %}',
+          }
+        );
+      });
+
+      $.get('{% url "explorer:pixelset_detail_quality_scores" pixelset.id %}', function (data) {
+        scoresChart.draw(
+          new google.visualization.DataTable(data),
+          {
+            height: 300,
+            legend: { position: 'none' },
+            title: '{% trans "Quality scores" %}',
+          }
+        );
+      });
+    }
+  </script>
+{% endblock javascript %}

--- a/apps/explorer/urls.py
+++ b/apps/explorer/urls.py
@@ -22,6 +22,16 @@ urlpatterns = [
         name='pixelset_detail'
     ),
     url(
+        r'^pixelset/(?P<pk>{})/values.json$'.format(UUID_REGEX),
+        views.PixelSetDetailValuesView.as_view(),
+        name='pixelset_detail_values'
+    ),
+    url(
+        r'^pixelset/(?P<pk>{})/quality-scores.json$'.format(UUID_REGEX),
+        views.PixelSetDetailQualityScoresView.as_view(),
+        name='pixelset_detail_quality_scores'
+    ),
+    url(
         r'^pixelset/clear$',
         views.PixelSetSelectionClearView.as_view(),
         name='pixelset_selection_clear'

--- a/apps/explorer/views.py
+++ b/apps/explorer/views.py
@@ -1,6 +1,7 @@
 from django.db.models import Q
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
+from django.core.exceptions import SuspiciousOperation
 from django.http import HttpResponse, HttpResponseRedirect
 from django.urls.base import reverse
 from django.utils import timezone
@@ -10,6 +11,7 @@ from django.views.generic import (
 )
 from django.views.generic.detail import BaseDetailView
 from django.views.generic.edit import FormMixin
+from gviz_api import DataTable
 
 from apps.core.models import OmicsArea, PixelSet, Tag
 from .forms import (
@@ -423,3 +425,37 @@ class PixelSetExportPixelsView(LoginRequiredMixin, BaseDetailView):
         )
 
         return response
+
+
+class PixelSetDetailValuesView(LoginRequiredMixin, BaseDetailView):
+
+    model = PixelSet
+
+    def get(self, request, *args, **kwargs):
+
+        if not request.is_ajax():
+            raise SuspiciousOperation(
+                'This endpoint should only be called from JavaScript.'
+            )
+
+        dt = DataTable({'id': ('string'), 'value': ('number')})
+        dt.LoadData(self.get_object().pixels.values('id', 'value'))
+
+        return HttpResponse(dt.ToJSon(), content_type='application/json')
+
+
+class PixelSetDetailQualityScoresView(LoginRequiredMixin, BaseDetailView):
+
+    model = PixelSet
+
+    def get(self, request, *args, **kwargs):
+
+        if not request.is_ajax():
+            raise SuspiciousOperation(
+                'This endpoint should only be called from JavaScript.'
+            )
+
+        dt = DataTable({'id': ('string'), 'quality_score': ('number')})
+        dt.LoadData(self.get_object().pixels.values('id', 'quality_score'))
+
+        return HttpResponse(dt.ToJSon(), content_type='application/json')

--- a/apps/explorer/views.py
+++ b/apps/explorer/views.py
@@ -331,11 +331,20 @@ class PixelSetDetailView(LoginRequiredMixin, FormMixin, DetailView):
 
         return get_omics_units_for_export(self.request.session)
 
+    def get_queryset(self):
+
+        qs = super().get_queryset().select_related(
+            'analysis__pixeler',
+        )
+
+        return qs
+
     def get_context_data(self, **kwargs):
 
         context = super().get_context_data(**kwargs)
 
-        qs = self.object.pixels.prefetch_related('omics_unit__reference')
+        qs = self.object.pixels.select_related('omics_unit__reference')
+
         omics_units = self.get_omics_units()
 
         if len(omics_units) > 0:
@@ -345,7 +354,10 @@ class PixelSetDetailView(LoginRequiredMixin, FormMixin, DetailView):
 
         context.update({
             'pixels': pixels,
+            'pixels_count': len(pixels),
             'pixels_limit': self.pixels_limit,
+            'total_count': self.object.pixels.count(),
+            'pixelset_experiments': self.object.analysis.experiments.all(),
         })
         return context
 

--- a/assets/scss/_explorer.scss
+++ b/assets/scss/_explorer.scss
@@ -198,6 +198,19 @@
     }
   }
 
+  .pixelset-distributions {
+    @include xy-grid($wrap: false);
+
+    .histogram {
+      @include breakpoint(medium) {
+        @include xy-cell($size: 6, $gutter-output: false);
+      }
+
+      text-align: center;
+      padding: 2em 1em;
+    }
+  }
+
   table.pixels {
     .value,
     .quality-score {


### PR DESCRIPTION
Fix #220

---

I decided to load the charts data from JavaScript because we can likely have a
lot of pixels for a pixel set.

<img width="1392" alt="screen shot 2018-02-06 at 16 02 31" src="https://user-images.githubusercontent.com/217628/35866426-72116584-0b57-11e8-886f-8f9076673905.png">

![2018-02-06 16 04 05](https://user-images.githubusercontent.com/217628/35866464-90192756-0b57-11e8-822a-b30c4bd1b526.gif)

(the gif is not really accurate since my laptop is busy inserting millions of pixels to test the app under heady load... :trollface: )

