### PR TITLE
Subset selection should look for "terms" in description fields

### DIFF
--- a/apps/explorer/forms.py
+++ b/apps/explorer/forms.py
@@ -102,7 +102,7 @@ class SessionPixelSetSelectForm(forms.Form):
 
 class PixelSetSubsetSelectionForm(forms.Form):
 
-    omics_units = forms.CharField(
+    search_terms = forms.CharField(
         widget=forms.Textarea(
             attrs={
                 'placeholder': _('CAGL0F02695g, CAGL0D06336g, CAGL0G06666g'),
@@ -116,5 +116,5 @@ class PixelSetSubsetSelectionForm(forms.Form):
         required=False,
     )
 
-    def clean_omics_units(self):
-        return list(str_to_set(self.cleaned_data['omics_units']))
+    def clean_search_terms(self):
+        return list(str_to_set(self.cleaned_data['search_terms']))

--- a/apps/explorer/templates/explorer/_subset_selection.html
+++ b/apps/explorer/templates/explorer/_subset_selection.html
@@ -25,8 +25,8 @@
       </button>
 
       {% if is_selection %}
-        {% with request.session.explorer.pixelset_selection_omics_units as omics_units %}
-          {% if omics_units and pixels_count > 0 %}
+        {% with request.session.explorer.pixelset_selection_search_terms as search_terms %}
+          {% if search_terms and pixels_count > 0 %}
             <a class="button" href="{% url "explorer:pixelset_export" %}?only-subset=1">
               <i class="fa fa-download" aria-hidden="true"></i>
               {% trans "Export this subset only" %}
@@ -44,8 +44,8 @@
           </a>
         {% endwith %}
       {% else %}
-        {% with request.session.explorer.pixelset_detail_omics_units as omics_units %}
-          {% if omics_units and pixels_count > 0 %}
+        {% with request.session.explorer.pixelset_detail_search_terms as search_terms %}
+          {% if search_terms and pixels_count > 0 %}
             <a class="button" href="{{ pixelset.get_export_pixels_url }}">
               <i class="fa fa-download" aria-hidden="true"></i>
               {% trans "Download a CSV file with the selected Pixels" %}

--- a/apps/explorer/tests/utils/test_export.py
+++ b/apps/explorer/tests/utils/test_export.py
@@ -192,9 +192,9 @@ class ExportPixelSetsTestCase(CoreFixturesTestCase):
 
 class ExportPixelsTestCase(CoreFixturesTestCase):
 
-    def _export_pixels(self, pixel_set, omics_units=[]):
+    def _export_pixels(self, pixel_set, search_terms=[]):
 
-        csv = export_pixels(pixel_set, omics_units=omics_units)
+        csv = export_pixels(pixel_set, search_terms=search_terms)
         csv.seek(0)
         return pandas.read_csv(csv).to_dict()
 
@@ -210,7 +210,7 @@ class ExportPixelsTestCase(CoreFixturesTestCase):
         assert 'Value' in pixels_csv
         assert 'QS' in pixels_csv
 
-    def test_export_all_pixels_when_no_omics_units_specified(self):
+    def test_export_all_pixels_when_no_search_terms_supplied(self):
 
         pixel_set = factories.PixelSetFactory.create()
         pixels = factories.PixelFactory.create_batch(3, pixel_set=pixel_set)
@@ -237,7 +237,7 @@ class ExportPixelsTestCase(CoreFixturesTestCase):
 
         pixels_csv = self._export_pixels(
             pixel_set,
-            omics_units=[selected_pixel.omics_unit.reference.identifier]
+            search_terms=[selected_pixel.omics_unit.reference.identifier]
         )
 
         assert len(pixels_csv['Omics Unit'].items()) == 1
@@ -426,7 +426,7 @@ class ExportPixelsetsAsHtmlTestCase(CoreFixturesTestCase):
 
         html = export_pixelsets_as_html(
           pixel_set_ids=pixel_set_ids,
-          omics_units=omics_units,
+          search_terms=omics_units,
         )
         self.assertInHTML('<th>0</th>', html)
         self.assertNotInHTML('<th>1</th>', html)

--- a/apps/explorer/tests/utils/test_export.py
+++ b/apps/explorer/tests/utils/test_export.py
@@ -192,7 +192,7 @@ class ExportPixelSetsTestCase(CoreFixturesTestCase):
 
 class ExportPixelsTestCase(CoreFixturesTestCase):
 
-    def _export_pixels(self, pixel_set, search_terms=[]):
+    def _export_pixels(self, pixel_set, search_terms=None):
 
         csv = export_pixels(pixel_set, search_terms=search_terms)
         csv.seek(0)

--- a/apps/explorer/tests/views/test_helpers.py
+++ b/apps/explorer/tests/views/test_helpers.py
@@ -1,28 +1,28 @@
 from apps.explorer.views.helpers import (
-    get_omics_units_from_session, get_selected_pixel_sets_from_session,
-    set_omics_units_to_session, set_selected_pixel_sets_to_session,
+    get_search_terms_from_session, get_selected_pixel_sets_from_session,
+    set_search_terms_to_session, set_selected_pixel_sets_to_session,
 )
 
 
-def test_get_omics_units_from_session_returns_empty_list():
+def test_get_search_terms_from_session_returns_empty_list():
 
     empty_session = dict()
 
-    omics_units = get_omics_units_from_session(empty_session, key='foo')
-    assert omics_units == []
+    search_terms = get_search_terms_from_session(empty_session, key='foo')
+    assert search_terms == []
 
 
-def test_get_omics_units_from_session_returns_default_if_supplied():
+def test_get_search_terms_from_session_returns_default_if_supplied():
 
     empty_session = dict()
     default = 'some-default-value'
 
-    omics_units = get_omics_units_from_session(
+    search_terms = get_search_terms_from_session(
         empty_session,
         key='foo',
         default=default
     )
-    assert omics_units == default
+    assert search_terms == default
 
 
 def test_get_selected_pixel_sets_from_session_returns_empty_list():
@@ -45,42 +45,42 @@ def test_get_selected_pixel_sets_from_session_returns_default_if_supplied():
     assert selected_pixel_sets == default
 
 
-def test_set_omics_units_to_session():
+def test_set_search_terms_to_session():
 
     session = dict()
-    omics_units = ['bar']
+    search_terms = ['bar']
 
-    set_omics_units_to_session(
+    set_search_terms_to_session(
         session,
         key='foo',
-        omics_units=omics_units
+        search_terms=search_terms
     )
     assert 'explorer' in session
     assert 'foo' in session['explorer']
-    assert session['explorer']['foo'] == omics_units
+    assert session['explorer']['foo'] == search_terms
 
 
-def test_set_omics_units_to_session_preserves_other_values():
+def test_set_search_terms_to_session_preserves_other_values():
 
     session = dict()
 
     # create a default session, without anything inside
-    set_omics_units_to_session(session, key='something-else')
+    set_search_terms_to_session(session, key='something-else')
     assert 'explorer' in session
     assert 'something-else' in session['explorer']
 
     # set omics units now
-    omics_units = ['bar']
+    search_terms = ['bar']
 
-    set_omics_units_to_session(
+    set_search_terms_to_session(
         session,
         key='foo',
-        omics_units=omics_units
+        search_terms=search_terms
     )
     assert 'explorer' in session
     assert 'foo' in session['explorer']
     assert 'something-else' in session['explorer']
-    assert session['explorer']['foo'] == omics_units
+    assert session['explorer']['foo'] == search_terms
 
 
 def test_set_selected_pixel_sets_to_session():
@@ -102,7 +102,7 @@ def test_set_selected_pixel_sets_to_session_preserves_other_values():
     session = dict()
 
     # create a default session, without anything inside
-    set_omics_units_to_session(session, key='something-else')
+    set_search_terms_to_session(session, key='something-else')
     assert 'explorer' in session
     assert 'something-else' in session['explorer']
 

--- a/apps/explorer/tests/views/test_mixins.py
+++ b/apps/explorer/tests/views/test_mixins.py
@@ -7,27 +7,27 @@ from apps.explorer.views.mixins import DataTableMixin, SubsetSelectionMixin
 
 class DataTableMixinTestCase(TestCase):
 
-    def test_get_omics_units_must_be_implemented(self):
+    def test_get_search_terms_must_be_implemented(self):
 
-        class DataTableWithNoGetOmicsUnits(DataTableMixin):
+        class DataTableWithNoGetSearchTerms(DataTableMixin):
             pass
 
         with pytest.raises(NotImplementedError):
             fake_session = dict()
 
-            obj = DataTableWithNoGetOmicsUnits()
-            obj.get_omics_units(fake_session)
+            obj = DataTableWithNoGetSearchTerms()
+            obj.get_search_terms(fake_session)
 
 
 class SubsetSelectionMixinTestCase(TestCase):
 
-    def test_get_omics_units_must_be_implemented(self):
+    def test_get_search_terms_must_be_implemented(self):
 
-        class SubsetSelectionWithNoGetOmicsUnits(SubsetSelectionMixin):
+        class SubsetSelectionWithNoGetSearchTerms(SubsetSelectionMixin):
             pass
 
         with pytest.raises(NotImplementedError):
             fake_session = dict()
 
-            obj = SubsetSelectionWithNoGetOmicsUnits()
-            obj.get_omics_units(fake_session)
+            obj = SubsetSelectionWithNoGetSearchTerms()
+            obj.get_search_terms(fake_session)

--- a/apps/explorer/tests/views/test_mixins.py
+++ b/apps/explorer/tests/views/test_mixins.py
@@ -18,6 +18,15 @@ class DataTableMixinTestCase(TestCase):
             obj = DataTableWithNoGetSearchTerms()
             obj.get_search_terms(fake_session)
 
+    def test_get_pixels_queryset_must_be_implemented(self):
+
+        class DataTableWithoGetPixelsQuerySet(DataTableMixin):
+            pass
+
+        with pytest.raises(NotImplementedError):
+            obj = DataTableWithoGetPixelsQuerySet()
+            obj.get_pixels_queryset()
+
 
 class SubsetSelectionMixinTestCase(TestCase):
 

--- a/apps/explorer/tests/views/test_views.py
+++ b/apps/explorer/tests/views/test_views.py
@@ -23,7 +23,7 @@ from apps.explorer.views import (
     DataTableDetailView,
 )
 from apps.explorer.views.helpers import get_selected_pixel_sets_from_session
-from apps.explorer.views.views_detail import GetOmicsUnitsMixin
+from apps.explorer.views.views_detail import GetSearchTermsMixin
 
 
 class PixelSetListViewTestCase(CoreFixturesTestCase):
@@ -1126,7 +1126,7 @@ class PixelSetDeselectViewTestCase(CoreFixturesTestCase):
         )
 
 
-class PixelSetExportViewTestCase(GetOmicsUnitsMixin, CoreFixturesTestCase):
+class PixelSetExportViewTestCase(GetSearchTermsMixin, CoreFixturesTestCase):
 
     def setUp(self):
 
@@ -1201,14 +1201,14 @@ class PixelSetExportViewTestCase(GetOmicsUnitsMixin, CoreFixturesTestCase):
         response = self.client.get(self.url)
 
         self.assertIsNone(
-            self.get_omics_units(self.client.session, default=None)
+            self.get_search_terms(self.client.session, default=None)
         )
 
         selected_pixel = pixels[1]
 
-        # set `omics_units` in session
+        # set search terms in session
         response = self.client.post(reverse('explorer:pixelset_selection'), {
-            'omics_units': selected_pixel.omics_unit.reference.identifier,
+            'search_terms': selected_pixel.omics_unit.reference.identifier,
         }, follow=True)
 
         fake_dt = timezone.make_aware(datetime.datetime(2018, 1, 12, 11, 00))
@@ -1240,7 +1240,7 @@ class PixelSetExportViewTestCase(GetOmicsUnitsMixin, CoreFixturesTestCase):
                 zip.close()
 
 
-class PixelSetDetailViewTestCase(GetOmicsUnitsMixin, CoreFixturesTestCase):
+class PixelSetDetailViewTestCase(GetSearchTermsMixin, CoreFixturesTestCase):
 
     def setUp(self):
 
@@ -1420,15 +1420,15 @@ class PixelSetDetailViewTestCase(GetOmicsUnitsMixin, CoreFixturesTestCase):
         session = self.client.session
         omics_unit_id = self.pixels[0].omics_unit.reference.identifier
 
-        self.assertIsNone(self.get_omics_units(session, default=None))
+        self.assertIsNone(self.get_search_terms(session, default=None))
 
         response = self.client.post(self.url, {
-            'omics_units': omics_unit_id,
+            'search_terms': omics_unit_id,
         }, follow=True)
 
         self.assertRedirects(response, self.pixel_set.get_absolute_url())
         self.assertEqual(
-            self.get_omics_units(self.client.session),
+            self.get_search_terms(self.client.session),
             [omics_unit_id]
         )
         self.assertContains(
@@ -1445,15 +1445,15 @@ class PixelSetDetailViewTestCase(GetOmicsUnitsMixin, CoreFixturesTestCase):
 
         session = self.client.session
 
-        self.assertIsNone(self.get_omics_units(session, default=None))
+        self.assertIsNone(self.get_search_terms(session, default=None))
 
         response = self.client.post(self.url, {
-            'omics_units': 'invalid',
+            'search_terms': 'invalid',
         }, follow=True)
 
         self.assertRedirects(response, self.pixel_set.get_absolute_url())
         self.assertEqual(
-            self.get_omics_units(self.client.session),
+            self.get_search_terms(self.client.session),
             ['invalid']
         )
         self.assertContains(
@@ -1472,15 +1472,15 @@ class PixelSetDetailViewTestCase(GetOmicsUnitsMixin, CoreFixturesTestCase):
         omics_unit_id_1 = self.pixels[0].omics_unit.reference.identifier
         omics_unit_id_2 = self.pixels[1].omics_unit.reference.identifier
 
-        self.assertIsNone(self.get_omics_units(session, default=None))
+        self.assertIsNone(self.get_search_terms(session, default=None))
 
         response = self.client.post(self.url, {
-            'omics_units': f'{omics_unit_id_1}, {omics_unit_id_2}',
+            'search_terms': f'{omics_unit_id_1}, {omics_unit_id_2}',
         }, follow=True)
 
         self.assertRedirects(response, self.pixel_set.get_absolute_url())
         self.assertEqual(
-            set(self.get_omics_units(self.client.session)),
+            set(self.get_search_terms(self.client.session)),
             set([omics_unit_id_1, omics_unit_id_2])
         )
         self.assertContains(
@@ -1492,12 +1492,12 @@ class PixelSetDetailViewTestCase(GetOmicsUnitsMixin, CoreFixturesTestCase):
     def test_empty_subset_returns_all_pixels(self):
 
         session = self.client.session
-        self.assertIsNone(self.get_omics_units(session, default=None))
+        self.assertIsNone(self.get_search_terms(session, default=None))
 
         response = self.client.post(self.url, follow=True)
 
         self.assertRedirects(response, self.pixel_set.get_absolute_url())
-        self.assertIsNone(self.get_omics_units(session, default=None))
+        self.assertIsNone(self.get_search_terms(session, default=None))
         self.assertContains(
             response,
             '<tr class="pixel">',
@@ -1559,7 +1559,7 @@ class PixelSetExportPixelsViewTestCase(CoreFixturesTestCase):
             )
 
 
-class PixelSetDetailValuesViewTestCase(GetOmicsUnitsMixin,
+class PixelSetDetailValuesViewTestCase(GetSearchTermsMixin,
                                        CoreFixturesTestCase):
 
     def setUp(self):
@@ -1616,11 +1616,11 @@ class PixelSetDetailValuesViewTestCase(GetOmicsUnitsMixin,
         session = self.client.session
         selected_pixel = self.pixels[0]
 
-        self.assertIsNone(self.get_omics_units(session, default=None))
+        self.assertIsNone(self.get_search_terms(session, default=None))
 
-        # set `omics_units` in session
+        # set search terms in session
         response = self.client.post(self.pixel_set.get_absolute_url(), {
-            'omics_units': selected_pixel.omics_unit.reference.identifier,
+            'search_terms': selected_pixel.omics_unit.reference.identifier,
         }, follow=True)
 
         self.assertRedirects(response, self.pixel_set.get_absolute_url())
@@ -1646,7 +1646,7 @@ class PixelSetDetailValuesViewTestCase(GetOmicsUnitsMixin,
         self.assertEqual(rows[0]['c'][1]['v'], selected_pixel.value)
 
 
-class PixelSetDetailQualityScoresViewTestCase(GetOmicsUnitsMixin,
+class PixelSetDetailQualityScoresViewTestCase(GetSearchTermsMixin,
                                               CoreFixturesTestCase):
 
     def setUp(self):
@@ -1703,11 +1703,11 @@ class PixelSetDetailQualityScoresViewTestCase(GetOmicsUnitsMixin,
         session = self.client.session
         selected_pixel = self.pixels[0]
 
-        self.assertIsNone(self.get_omics_units(session, default=None))
+        self.assertIsNone(self.get_search_terms(session, default=None))
 
-        # set `omics_units` in session
+        # set search terms in session
         response = self.client.post(self.pixel_set.get_absolute_url(), {
-            'omics_units': selected_pixel.omics_unit.reference.identifier,
+            'search_terms': selected_pixel.omics_unit.reference.identifier,
         }, follow=True)
 
         self.assertRedirects(response, self.pixel_set.get_absolute_url())

--- a/apps/explorer/tests/views/test_views.py
+++ b/apps/explorer/tests/views/test_views.py
@@ -1611,7 +1611,45 @@ class PixelSetDetailValuesViewTestCase(GetSearchTermsMixin,
         rows = data['rows']
         self.assertEqual(len(rows), 2)
 
-    def test_filters_by_omics_units(self):
+    def test_filters_by_term_in_description(self):
+
+        session = self.client.session
+
+        selected_pixel = self.pixels[0]
+
+        description = selected_pixel.omics_unit.reference.description
+        first_words = description.split(' ')[0:2]
+
+        self.assertIsNone(self.get_search_terms(session, default=None))
+
+        # set search terms in session
+        response = self.client.post(self.pixel_set.get_absolute_url(), {
+            'search_terms': first_words,
+        }, follow=True)
+
+        self.assertRedirects(response, self.pixel_set.get_absolute_url())
+
+        response = self.client.get(
+            self.url,
+            data={},
+            HTTP_X_REQUESTED_WITH='XMLHttpRequest'
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response['Content-Type'], 'application/json')
+
+        data = json.loads(response.content)
+
+        cols = data['cols']
+        self.assertEqual(cols[0]['label'], 'id')
+        self.assertEqual(cols[1]['label'], 'value')
+
+        rows = data['rows']
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]['c'][0]['v'], str(selected_pixel.id))
+        self.assertEqual(rows[0]['c'][1]['v'], selected_pixel.value)
+
+    def test_filters_by_(self):
 
         session = self.client.session
         selected_pixel = self.pixels[0]
@@ -1708,6 +1746,44 @@ class PixelSetDetailQualityScoresViewTestCase(GetSearchTermsMixin,
         # set search terms in session
         response = self.client.post(self.pixel_set.get_absolute_url(), {
             'search_terms': selected_pixel.omics_unit.reference.identifier,
+        }, follow=True)
+
+        self.assertRedirects(response, self.pixel_set.get_absolute_url())
+
+        response = self.client.get(
+            self.url,
+            data={},
+            HTTP_X_REQUESTED_WITH='XMLHttpRequest'
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response['Content-Type'], 'application/json')
+
+        data = json.loads(response.content)
+
+        cols = data['cols']
+        self.assertEqual(cols[0]['label'], 'id')
+        self.assertEqual(cols[1]['label'], 'quality_score')
+
+        rows = data['rows']
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]['c'][0]['v'], str(selected_pixel.id))
+        self.assertEqual(rows[0]['c'][1]['v'], selected_pixel.quality_score)
+
+    def test_filters_by_term_in_description(self):
+
+        session = self.client.session
+
+        selected_pixel = self.pixels[0]
+
+        description = selected_pixel.omics_unit.reference.description
+        first_words = description.split(' ')[0:2]
+
+        self.assertIsNone(self.get_search_terms(session, default=None))
+
+        # set search terms in session
+        response = self.client.post(self.pixel_set.get_absolute_url(), {
+            'search_terms': first_words,
         }, follow=True)
 
         self.assertRedirects(response, self.pixel_set.get_absolute_url())

--- a/apps/explorer/tests/views/test_views_selection.py
+++ b/apps/explorer/tests/views/test_views_selection.py
@@ -7,7 +7,7 @@ from django.test import TestCase
 from apps.core import factories
 from apps.core.tests import CoreFixturesTestCase
 from apps.explorer.views import DataTableCumulativeView, DataTableSelectionView
-from apps.explorer.views.views_selection import GetOmicsUnitsMixin
+from apps.explorer.views.views_selection import GetSearchTermsMixin
 
 
 class PixelSetSelectionViewTestCase(CoreFixturesTestCase):
@@ -128,7 +128,7 @@ class DataTableSelectionViewTestCase(TestCase):
             view.get_headers()
 
 
-class PixelSetSelectionValuesViewTestCase(GetOmicsUnitsMixin,
+class PixelSetSelectionValuesViewTestCase(GetSearchTermsMixin,
                                           CoreFixturesTestCase):
 
     def setUp(self):
@@ -192,13 +192,13 @@ class PixelSetSelectionValuesViewTestCase(GetOmicsUnitsMixin,
         )
         response = self.client.get(self.url)
 
-        self.assertIsNone(self.get_omics_units(session, default=None))
+        self.assertIsNone(self.get_search_terms(session, default=None))
 
         selected_pixel = self.pixels[0]
 
-        # set `omics_units` in session
+        # set search terms in session
         response = self.client.post(reverse('explorer:pixelset_selection'), {
-            'omics_units': selected_pixel.omics_unit.reference.identifier,
+            'search_terms': selected_pixel.omics_unit.reference.identifier,
         }, follow=True)
 
         self.assertRedirects(response, reverse('explorer:pixelset_selection'))
@@ -224,7 +224,7 @@ class PixelSetSelectionValuesViewTestCase(GetOmicsUnitsMixin,
         self.assertEqual(rows[0]['c'][1]['v'], selected_pixel.value)
 
 
-class PixelSetSelectionQualityScoresViewTestCase(GetOmicsUnitsMixin,
+class PixelSetSelectionQualityScoresViewTestCase(GetSearchTermsMixin,
                                                  CoreFixturesTestCase):
 
     def setUp(self):
@@ -288,13 +288,13 @@ class PixelSetSelectionQualityScoresViewTestCase(GetOmicsUnitsMixin,
         )
         response = self.client.get(self.url)
 
-        self.assertIsNone(self.get_omics_units(session, default=None))
+        self.assertIsNone(self.get_search_terms(session, default=None))
 
         selected_pixel = self.pixels[0]
 
-        # set `omics_units` in session
+        # set search terms in session
         response = self.client.post(reverse('explorer:pixelset_selection'), {
-            'omics_units': selected_pixel.omics_unit.reference.identifier,
+            'search_terms': selected_pixel.omics_unit.reference.identifier,
         }, follow=True)
 
         self.assertRedirects(response, reverse('explorer:pixelset_selection'))

--- a/apps/explorer/tests/views/test_views_selection.py
+++ b/apps/explorer/tests/views/test_views_selection.py
@@ -223,6 +223,52 @@ class PixelSetSelectionValuesViewTestCase(GetSearchTermsMixin,
         self.assertEqual(rows[0]['c'][0]['v'], str(selected_pixel.id))
         self.assertEqual(rows[0]['c'][1]['v'], selected_pixel.value)
 
+    def test_filters_by_term_in_description(self):
+
+        session = self.client.session
+
+        # select pixel set, otherwise we cannot set omics units
+        self.client.post(
+            reverse('explorer:pixelset_select'),
+            {'pixel_sets': [self.pixel_set.id]},
+            follow=True
+        )
+        response = self.client.get(self.url)
+
+        self.assertIsNone(self.get_search_terms(session, default=None))
+
+        selected_pixel = self.pixels[0]
+
+        description = selected_pixel.omics_unit.reference.description
+        first_word = description.split(' ')[0]
+
+        # set search terms in session
+        response = self.client.post(reverse('explorer:pixelset_selection'), {
+            'search_terms': first_word,
+        }, follow=True)
+
+        self.assertRedirects(response, reverse('explorer:pixelset_selection'))
+
+        response = self.client.get(
+            self.url,
+            data={},
+            HTTP_X_REQUESTED_WITH='XMLHttpRequest'
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response['Content-Type'], 'application/json')
+
+        data = json.loads(response.content)
+
+        cols = data['cols']
+        self.assertEqual(cols[0]['label'], 'id')
+        self.assertEqual(cols[1]['label'], 'value')
+
+        rows = data['rows']
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]['c'][0]['v'], str(selected_pixel.id))
+        self.assertEqual(rows[0]['c'][1]['v'], selected_pixel.value)
+
 
 class PixelSetSelectionQualityScoresViewTestCase(GetSearchTermsMixin,
                                                  CoreFixturesTestCase):
@@ -295,6 +341,52 @@ class PixelSetSelectionQualityScoresViewTestCase(GetSearchTermsMixin,
         # set search terms in session
         response = self.client.post(reverse('explorer:pixelset_selection'), {
             'search_terms': selected_pixel.omics_unit.reference.identifier,
+        }, follow=True)
+
+        self.assertRedirects(response, reverse('explorer:pixelset_selection'))
+
+        response = self.client.get(
+            self.url,
+            data={},
+            HTTP_X_REQUESTED_WITH='XMLHttpRequest'
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response['Content-Type'], 'application/json')
+
+        data = json.loads(response.content)
+
+        cols = data['cols']
+        self.assertEqual(cols[0]['label'], 'id')
+        self.assertEqual(cols[1]['label'], 'quality_score')
+
+        rows = data['rows']
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]['c'][0]['v'], str(selected_pixel.id))
+        self.assertEqual(rows[0]['c'][1]['v'], selected_pixel.quality_score)
+
+    def test_filters_by_term_in_description(self):
+
+        session = self.client.session
+
+        # select pixel set, otherwise we cannot set omics units
+        self.client.post(
+            reverse('explorer:pixelset_select'),
+            {'pixel_sets': [self.pixel_set.id]},
+            follow=True
+        )
+        response = self.client.get(self.url)
+
+        self.assertIsNone(self.get_search_terms(session, default=None))
+
+        selected_pixel = self.pixels[0]
+
+        description = selected_pixel.omics_unit.reference.description
+        first_word = description.split(' ')[0]
+
+        # set search terms in session
+        response = self.client.post(reverse('explorer:pixelset_selection'), {
+            'search_terms': first_word,
         }, follow=True)
 
         self.assertRedirects(response, reverse('explorer:pixelset_selection'))

--- a/apps/explorer/utils/__init__.py
+++ b/apps/explorer/utils/__init__.py
@@ -1,6 +1,7 @@
 from .export import (
     PIXELSET_EXPORT_META_FILENAME, PIXELSET_EXPORT_PIXELS_FILENAME,
     export_pixelsets, export_pixels, export_pixelsets_as_html,
+    get_queryset_filtered_by_search_terms,
 )
 
 
@@ -10,4 +11,5 @@ __all__ = (
     'export_pixels',
     'export_pixelsets',
     'export_pixelsets_as_html',
+    'get_queryset_filtered_by_search_terms',
 )

--- a/apps/explorer/utils/export.py
+++ b/apps/explorer/utils/export.py
@@ -15,13 +15,14 @@ PIXELSET_EXPORT_PIXELS_FILENAME = 'pixels.csv'
 
 
 def _get_pixelsets_dataframe_and_metadata(pixel_set_ids,
-                                          omics_units=None,
+                                          search_terms=None,
                                           descriptions=dict(),
                                           with_links=False):
-    """The function takes Pixel Set IDs and optionally a list of Omics Units, a
-    hash map of Pixel Set descriptions, and a boolean to determine whether to
-    build URLs for omics units. This function returns a pandas.DataFrame and a
-    hash map containing metadata related to the Pixel Sets.
+    """The function takes Pixel Set IDs and optionally a list of search terms
+    like Omics Units identifiers or terms in descriptions, a hash map of Pixel
+    Set descriptions, and a boolean to determine whether to build URLs for
+    omics units. This function returns a pandas.DataFrame and a hash map
+    containing metadata related to the Pixel Sets.
 
     The list of Omics Units should contain identifiers and will be used to
     filter the pixels.
@@ -31,11 +32,11 @@ def _get_pixelsets_dataframe_and_metadata(pixel_set_ids,
 
     pixel_set_ids: list
         A list of Pixel Set ids.
-    omics_units: list
-        A list of Omics Units ids.
-    descriptions: dict
+    search_terms: list, optional
+        A list of search terms.
+    descriptions: dict, optional
         A hash map containing Pixel Set descriptions indexed by ID.
-    with_links: bool
+    with_links: bool, optional
         Whether the omics units should have URLs or not.
 
     Returns
@@ -90,8 +91,8 @@ def _get_pixelsets_dataframe_and_metadata(pixel_set_ids,
         for pixel in qs:
             omics_unit = pixel.omics_unit.reference.identifier
 
-            # filter by omics_units if supplied
-            if omics_units and omics_unit not in omics_units:
+            # filter by search_terms if supplied
+            if search_terms and omics_unit not in search_terms:
                 continue
 
             description = pixel.omics_unit.reference.description
@@ -135,7 +136,7 @@ def _get_pixelsets_dataframe_and_metadata(pixel_set_ids,
     return df, meta
 
 
-def export_pixelsets(pixel_sets, omics_units=[]):
+def export_pixelsets(pixel_sets, search_terms=[]):
     """This function exports a list of PixelSet objects as a ZIP archive.
 
     The (in-memory) ZIP archive contains a `meta.yaml` file and a `pixels.csv`
@@ -146,6 +147,8 @@ def export_pixelsets(pixel_sets, omics_units=[]):
     pixel_sets : iterable
         A sequence, an iterator, or some other object which supports iteration,
         containing PixelSet objects.
+    search_terms: list, optional
+        A list of search terms.
 
     Returns
     -------
@@ -160,7 +163,7 @@ def export_pixelsets(pixel_sets, omics_units=[]):
 
     df, pixelsets_meta = _get_pixelsets_dataframe_and_metadata(
         pixel_set_ids=descriptions.keys(),
-        omics_units=omics_units,
+        search_terms=search_terms,
         descriptions=descriptions,
     )
 
@@ -192,17 +195,17 @@ def export_pixelsets(pixel_sets, omics_units=[]):
     return stream
 
 
-def export_pixels(pixel_set, omics_units=[], output=None):
+def export_pixels(pixel_set, search_terms=[], output=None):
     """This function exports the Pixels of a given PixelSet as a CSV file.
 
-    If the list of `omics_units` is empty, all Pixels will be exported.
+    If the list of `search_terms` is empty, all Pixels will be exported.
 
     Parameters
     ----------
     pixel_set : apps.core.models.PixelSet
         A PixelSet object.
-    omics_units: list, optional
-        A list of omics unit identifiers to export.
+    search_terms: list, optional
+        A list of search terms.
     output : String or File handler, optional
         A string or file handler to write the CSV content.
 
@@ -216,9 +219,9 @@ def export_pixels(pixel_set, omics_units=[], output=None):
 
     qs = pixel_set.pixels.select_related('omics_unit__reference')
 
-    # we only filter by Omics Units when specified.
-    if len(omics_units) > 0:
-        qs = qs.filter(omics_unit__reference__identifier__in=omics_units)
+    # filter by search terms
+    if len(search_terms) > 0:
+        qs = qs.filter(omics_unit__reference__identifier__in=search_terms)
 
     data = list(
         qs.values_list(
@@ -243,7 +246,7 @@ def export_pixels(pixel_set, omics_units=[], output=None):
 
 
 def export_pixelsets_as_html(pixel_set_ids,
-                             omics_units=None,
+                             search_terms=None,
                              display_limit=None):
     """This function creates a HTML table displaying the pixels related to the
     set of Pixel Sets given as first argument.
@@ -259,8 +262,8 @@ def export_pixelsets_as_html(pixel_set_ids,
 
     pixel_set_ids: list
         A list of Pixel Set ids.
-    omics_units: list
-        A list of Omics Units ids.
+    search_terms: list, optional
+        A list of search terms.
     display_limit: int
         The number of rows to render in the HTML table.
 
@@ -277,7 +280,7 @@ def export_pixelsets_as_html(pixel_set_ids,
 
     df, __ = _get_pixelsets_dataframe_and_metadata(
         pixel_set_ids,
-        omics_units=omics_units,
+        search_terms=search_terms,
         with_links=True,
     )
 

--- a/apps/explorer/views/helpers.py
+++ b/apps/explorer/views/helpers.py
@@ -1,6 +1,6 @@
 
 
-def get_omics_units_from_session(session, key, default=[]):
+def get_search_terms_from_session(session, key, default=[]):
 
     return session.get(
         'explorer', {}
@@ -18,10 +18,10 @@ def get_selected_pixel_sets_from_session(session, default=[]):
     )
 
 
-def set_omics_units_to_session(session, key, omics_units=[]):
+def set_search_terms_to_session(session, key, search_terms=[]):
 
     explorer = session.get('explorer', {})
-    explorer.update({key: omics_units})
+    explorer.update({key: search_terms})
 
     session['explorer'] = explorer
 

--- a/apps/explorer/views/mixins.py
+++ b/apps/explorer/views/mixins.py
@@ -7,6 +7,7 @@ from django.views.generic.edit import FormMixin
 from gviz_api import DataTable
 
 from ..forms import PixelSetSubsetSelectionForm
+from ..utils import get_queryset_filtered_by_search_terms
 
 from .helpers import set_search_terms_to_session
 
@@ -21,6 +22,12 @@ class DataTableMixin(object):
 
         raise NotImplementedError(_('You should define `get_headers()`'))
 
+    def get_pixels_queryset(self):
+
+        raise NotImplementedError(
+            _('You should define `get_pixels_queryset()`')
+        )
+
     def get_columns(self):
 
         return list(self.get_headers().keys())
@@ -33,13 +40,12 @@ class DataTableMixin(object):
                 'This endpoint should only be called from JavaScript.'
             )
 
-        qs = self.get_pixels_queryset()
-
         search_terms = self.get_search_terms(request.session)
 
-        # we only filter by search terms when specified
-        if len(search_terms) > 0:
-            qs = qs.filter(omics_unit__reference__identifier__in=search_terms)
+        qs = get_queryset_filtered_by_search_terms(
+            self.get_pixels_queryset(),
+            search_terms=search_terms
+        )
 
         dt = DataTable(self.get_headers())
         dt.LoadData(qs.values(*self.get_columns()))

--- a/apps/explorer/views/mixins.py
+++ b/apps/explorer/views/mixins.py
@@ -8,14 +8,14 @@ from gviz_api import DataTable
 
 from ..forms import PixelSetSubsetSelectionForm
 
-from .helpers import get_omics_units_from_session, set_omics_units_to_session
+from .helpers import set_search_terms_to_session
 
 
 class DataTableMixin(object):
 
-    def get_omics_units(self, session, **kwargs):
+    def get_search_terms(self, session, **kwargs):
 
-        raise NotImplementedError(_('You should define `get_omics_units()`'))
+        raise NotImplementedError(_('You should define `get_search_terms()`'))
 
     def get_headers(self):
 
@@ -35,11 +35,11 @@ class DataTableMixin(object):
 
         qs = self.get_pixels_queryset()
 
-        omics_units = self.get_omics_units(request.session)
+        search_terms = self.get_search_terms(request.session)
 
-        # we only filter by Omics Units when specified.
-        if len(omics_units) > 0:
-            qs = qs.filter(omics_unit__reference__identifier__in=omics_units)
+        # we only filter by search terms when specified
+        if len(search_terms) > 0:
+            qs = qs.filter(omics_unit__reference__identifier__in=search_terms)
 
         dt = DataTable(self.get_headers())
         dt.LoadData(qs.values(*self.get_columns()))
@@ -51,16 +51,18 @@ class SubsetSelectionMixin(FormMixin):
 
     form_class = PixelSetSubsetSelectionForm
 
-    def get_omics_units(self, session, **kwargs):
+    def get_search_terms(self, session, **kwargs):
 
-        raise NotImplementedError(_('You should define `get_omics_units()`'))
+        raise NotImplementedError(_('You should define `get_search_terms()`'))
 
     def get_initial(self):
 
         initial = super().get_initial()
 
         initial.update({
-            'omics_units': ' '.join(self.get_omics_units(self.request.session))
+            'search_terms': ' '.join(
+                self.get_search_terms(self.request.session)
+            )
         })
         return initial
 
@@ -69,10 +71,10 @@ class SubsetSelectionMixin(FormMixin):
         form = self.get_form()
 
         if form.is_valid():
-            set_omics_units_to_session(
+            set_search_terms_to_session(
                 request.session,
-                key=self.omics_units_session_key,
-                omics_units=form.cleaned_data['omics_units']
+                key=self.search_terms_session_key,
+                search_terms=form.cleaned_data['search_terms']
             )
 
             return self.form_valid(form)
@@ -80,16 +82,3 @@ class SubsetSelectionMixin(FormMixin):
             # We should never reach this code because the form should always be
             # valid (no required field or validation)
             return self.form_invalid(form)  # pragma: no cover
-
-
-class GetOmicsUnitsMixin(object):
-
-    omics_units_session_key = 'pixelset_selection_omics_units'
-
-    def get_omics_units(self, session, **kwargs):
-
-        return get_omics_units_from_session(
-            session,
-            key=self.omics_units_session_key,
-            **kwargs
-        )

--- a/apps/explorer/views/views_detail.py
+++ b/apps/explorer/views/views_detail.py
@@ -8,24 +8,24 @@ from apps.core.models import PixelSet
 
 from ..utils import export_pixels
 
-from .helpers import get_omics_units_from_session
+from .helpers import get_search_terms_from_session
 from .mixins import DataTableMixin, SubsetSelectionMixin
 
 
-class GetOmicsUnitsMixin(object):
+class GetSearchTermsMixin(object):
 
-    omics_units_session_key = 'pixelset_detail_omics_units'
+    search_terms_session_key = 'pixelset_detail_search_terms'
 
-    def get_omics_units(self, session, **kwargs):
+    def get_search_terms(self, session, **kwargs):
 
-        return get_omics_units_from_session(
+        return get_search_terms_from_session(
             session,
-            key=self.omics_units_session_key,
+            key=self.search_terms_session_key,
             **kwargs
         )
 
 
-class DataTableDetailView(LoginRequiredMixin, GetOmicsUnitsMixin,
+class DataTableDetailView(LoginRequiredMixin, GetSearchTermsMixin,
                           DataTableMixin,
                           BaseDetailView):
 
@@ -50,7 +50,7 @@ class PixelSetDetailQualityScoresView(DataTableDetailView):
         return {'id': ('string'), 'quality_score': ('number')}
 
 
-class PixelSetDetailView(LoginRequiredMixin, GetOmicsUnitsMixin,
+class PixelSetDetailView(LoginRequiredMixin, GetSearchTermsMixin,
                          SubsetSelectionMixin,
                          DetailView):
 
@@ -73,10 +73,10 @@ class PixelSetDetailView(LoginRequiredMixin, GetOmicsUnitsMixin,
 
         qs = self.object.pixels.select_related('omics_unit__reference')
 
-        omics_units = self.get_omics_units(self.request.session)
+        search_terms = self.get_search_terms(self.request.session)
 
-        if len(omics_units) > 0:
-            qs = qs.filter(omics_unit__reference__identifier__in=omics_units)
+        if len(search_terms) > 0:
+            qs = qs.filter(omics_unit__reference__identifier__in=search_terms)
 
         pixels = qs[:self.pixels_limit]
 
@@ -94,7 +94,7 @@ class PixelSetDetailView(LoginRequiredMixin, GetOmicsUnitsMixin,
         return self.get_object().get_absolute_url()
 
 
-class PixelSetExportPixelsView(LoginRequiredMixin, GetOmicsUnitsMixin,
+class PixelSetExportPixelsView(LoginRequiredMixin, GetSearchTermsMixin,
                                BaseDetailView):
 
     ATTACHEMENT_FILENAME = 'pixels_{date_time}.csv'
@@ -110,7 +110,7 @@ class PixelSetExportPixelsView(LoginRequiredMixin, GetOmicsUnitsMixin,
 
     def get(self, request, *args, **kwargs):
 
-        omics_units = self.get_omics_units(request.session)
+        search_terms = self.get_search_terms(request.session)
 
         response = HttpResponse(content_type='text/csv')
         response['Content-Disposition'] = 'attachment; filename={}'.format(
@@ -119,7 +119,7 @@ class PixelSetExportPixelsView(LoginRequiredMixin, GetOmicsUnitsMixin,
 
         export_pixels(
             self.get_object(),
-            omics_units=omics_units,
+            search_terms=search_terms,
             output=response
         )
 

--- a/apps/explorer/views/views_detail.py
+++ b/apps/explorer/views/views_detail.py
@@ -6,7 +6,7 @@ from django.views.generic.detail import BaseDetailView
 
 from apps.core.models import PixelSet
 
-from ..utils import export_pixels
+from ..utils import export_pixels, get_queryset_filtered_by_search_terms
 
 from .helpers import get_search_terms_from_session
 from .mixins import DataTableMixin, SubsetSelectionMixin
@@ -71,12 +71,11 @@ class PixelSetDetailView(LoginRequiredMixin, GetSearchTermsMixin,
 
         context = super().get_context_data(**kwargs)
 
-        qs = self.object.pixels.select_related('omics_unit__reference')
-
         search_terms = self.get_search_terms(self.request.session)
-
-        if len(search_terms) > 0:
-            qs = qs.filter(omics_unit__reference__identifier__in=search_terms)
+        qs = get_queryset_filtered_by_search_terms(
+            self.object.pixels.select_related('omics_unit__reference'),
+            search_terms=search_terms
+        )
 
         pixels = qs[:self.pixels_limit]
 

--- a/apps/explorer/views/views_list.py
+++ b/apps/explorer/views/views_list.py
@@ -21,7 +21,7 @@ from ..utils import export_pixelsets
 from .helpers import (
     get_selected_pixel_sets_from_session, set_selected_pixel_sets_to_session
 )
-from .mixins import GetOmicsUnitsMixin
+from .views_selection import GetSearchTermsMixin
 
 
 class PixelSetListView(LoginRequiredMixin, FormMixin, ListView):
@@ -257,7 +257,7 @@ class PixelSetSelectView(LoginRequiredMixin, FormView):
         return HttpResponseRedirect(self.get_success_url())
 
 
-class PixelSetExportView(LoginRequiredMixin, GetOmicsUnitsMixin, View):
+class PixelSetExportView(LoginRequiredMixin, GetSearchTermsMixin, View):
 
     ATTACHEMENT_FILENAME = 'pixelsets_{date_time}.zip'
     SUBSET_QUERY_PARAM = 'only-subset'
@@ -275,15 +275,15 @@ class PixelSetExportView(LoginRequiredMixin, GetOmicsUnitsMixin, View):
         if not len(selection):
             return self.empty_selection(request)
 
-        omics_units = []
+        search_terms = []
         # only take omics units into account if it is requested.
         if request.GET.get(self.SUBSET_QUERY_PARAM, False):
-            omics_units = self.get_omics_units(self.request.session)
+            search_terms = self.get_search_terms(self.request.session)
 
         qs = PixelSet.objects.filter(id__in=selection)
         content = export_pixelsets(
             pixel_sets=qs,
-            omics_units=omics_units,
+            search_terms=search_terms,
         ).getvalue()
 
         response = HttpResponse(content, content_type='application/zip')

--- a/apps/explorer/views/views_selection.py
+++ b/apps/explorer/views/views_selection.py
@@ -8,7 +8,10 @@ from django.views.generic.detail import BaseDetailView
 
 from apps.core.models import Pixel, PixelSet
 
-from ..utils import export_pixelsets_as_html
+from ..utils import (
+    export_pixelsets_as_html,
+    get_queryset_filtered_by_search_terms
+)
 
 from .helpers import (
     get_search_terms_from_session,
@@ -126,9 +129,10 @@ class PixelSetSelectionView(LoginRequiredMixin, GetSearchTermsMixin,
         )
 
         search_terms = self.get_search_terms(self.request.session)
-
-        if len(search_terms) > 0:
-            qs = qs.filter(omics_unit__reference__identifier__in=search_terms)
+        qs = get_queryset_filtered_by_search_terms(
+            qs,
+            search_terms=search_terms
+        )
 
         pixels_count = qs.count()
 

--- a/apps/explorer/views/views_selection.py
+++ b/apps/explorer/views/views_selection.py
@@ -10,11 +10,27 @@ from apps.core.models import Pixel, PixelSet
 
 from ..utils import export_pixelsets_as_html
 
-from .helpers import get_selected_pixel_sets_from_session
-from .mixins import DataTableMixin, GetOmicsUnitsMixin, SubsetSelectionMixin
+from .helpers import (
+    get_search_terms_from_session,
+    get_selected_pixel_sets_from_session,
+)
+from .mixins import DataTableMixin, SubsetSelectionMixin
 
 
-class DataTableCumulativeView(LoginRequiredMixin, GetOmicsUnitsMixin,
+class GetSearchTermsMixin(object):
+
+    search_terms_session_key = 'pixelset_selection_search_terms'
+
+    def get_search_terms(self, session, **kwargs):
+
+        return get_search_terms_from_session(
+            session,
+            key=self.search_terms_session_key,
+            **kwargs
+        )
+
+
+class DataTableCumulativeView(LoginRequiredMixin, GetSearchTermsMixin,
                               DataTableMixin,
                               View):
 
@@ -41,7 +57,7 @@ class PixelSetSelectionCumulativeQualityScoresView(DataTableCumulativeView):
         return {'id': ('string'), 'quality_score': ('number')}
 
 
-class DataTableSelectionView(LoginRequiredMixin, GetOmicsUnitsMixin,
+class DataTableSelectionView(LoginRequiredMixin, GetSearchTermsMixin,
                              DataTableMixin,
                              BaseDetailView):
 
@@ -66,7 +82,7 @@ class PixelSetSelectionQualityScoresView(DataTableSelectionView):
         return {'id': ('string'), 'quality_score': ('number')}
 
 
-class PixelSetSelectionView(LoginRequiredMixin, GetOmicsUnitsMixin,
+class PixelSetSelectionView(LoginRequiredMixin, GetSearchTermsMixin,
                             SubsetSelectionMixin,
                             TemplateView):
 
@@ -109,10 +125,10 @@ class PixelSetSelectionView(LoginRequiredMixin, GetOmicsUnitsMixin,
             'omics_unit__reference'
         )
 
-        omics_units = self.get_omics_units(self.request.session)
+        search_terms = self.get_search_terms(self.request.session)
 
-        if len(omics_units) > 0:
-            qs = qs.filter(omics_unit__reference__identifier__in=omics_units)
+        if len(search_terms) > 0:
+            qs = qs.filter(omics_unit__reference__identifier__in=search_terms)
 
         pixels_count = qs.count()
 
@@ -122,7 +138,7 @@ class PixelSetSelectionView(LoginRequiredMixin, GetOmicsUnitsMixin,
 
         html_table = export_pixelsets_as_html(
             selected_pixelset_ids,
-            omics_units=omics_units,
+            search_terms=search_terms,
             # we do not display all the data
             display_limit=self.omics_units_limit,
         )


### PR DESCRIPTION
Fix #221 
Fix #254

---

This will be useful as semantics has changed: we do not only enter omics units in the textarea but "search terms" that are either omics units or words present in descriptions.

**Edit:** I actually pushed the feature itself in this PR! 🎉 

The feature is implemented for both the detail view and the multi-pixelsets selection view!