### PR TITLE
Fixes #260 - avoid nginx 413 (Request Entity Too Large) error

### DIFF
--- a/docker/etc/nginx/conf.d/pixel.conf
+++ b/docker/etc/nginx/conf.d/pixel.conf
@@ -12,6 +12,9 @@ server {
 
   listen 80;
 
+  # avoid 413 (Request Entity Too Large) error
+  client_max_body_size 100m;
+
   location /static/ {
     alias /app/pixel/public/static/;
   }


### PR DESCRIPTION
Parameter by default: 1m
Increase to 100m