### PR TITLE
Fix bootstrap

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,21 +11,21 @@ ARG BUILD_DATE
 ARG VCS_REF
 ARG VERSION
 LABEL org.label-schema.build-date=$BUILD_DATE \
-      org.label-schema.name="Pixel" \
-      org.label-schema.description="Integration of smart 'omics' data" \
-      org.label-schema.url="https://pixel.candihub.eu/" \
-      org.label-schema.vcs-ref=$VCS_REF \
-      org.label-schema.vcs-url="https://github.com/Candihub/pixel/" \
-      org.label-schema.vendor="CandiHub" \
-      org.label-schema.version=$VERSION \
-      org.label-schema.schema-version="1.0"
+    org.label-schema.name="Pixel" \
+    org.label-schema.description="Integration of smart 'omics' data" \
+    org.label-schema.url="https://pixel.candihub.eu/" \
+    org.label-schema.vcs-ref=$VCS_REF \
+    org.label-schema.vcs-url="https://github.com/Candihub/pixel/" \
+    org.label-schema.vendor="CandiHub" \
+    org.label-schema.version=$VERSION \
+    org.label-schema.schema-version="1.0"
 
 # Install Pipenv
 RUN pip install pipenv --upgrade
 
 # Add a non-privileged user for installing and running
 # the application
-RUN groupadd --gid $GID app && \
+RUN groupadd -f --gid $GID app && \
     useradd --uid $UID --gid $GID --home /app --create-home app
 
 RUN su app -c "mkdir /app/pixel"

--- a/Makefile
+++ b/Makefile
@@ -4,16 +4,11 @@ FONTS_DIR         = static/fonts
 FOUNDATION_PATH = node_modules/foundation-sites
 FA_PATH = node_modules/font-awesome
 
-# Node
-YARN_RUN = yarn
-NODEMON  = $(YARN_RUN) nodemon
-POSTCSS  = $(YARN_RUN) postcss
-SASS     = $(YARN_RUN) node-sass
-
 # Docker
 COMPOSE              = bin/compose
 COMPOSE_RUN          = $(COMPOSE) run --rm
 COMPOSE_RUN_WEB      = $(COMPOSE_RUN) web
+COMPOSE_RUN_NODE     = $(COMPOSE_RUN) node
 MANAGE               = bin/manage
 COMPOSE_TEST         = docker-compose -f docker-compose.test.yml -p pixel-test
 COMPOSE_TEST_RUN     = $(COMPOSE_TEST) run --rm


### PR DESCRIPTION
## Purpose

As mentioned in #305, the `make bootstrap` command fails it `yarn` is not installed locally.

## Proposal

- [x] Ensure we are using the `node` container so that Docker is the only dependency
- [x] Fix node group creation if it already exists in the base Docker image

Fix #305 